### PR TITLE
[DPE-6370] chore: keep vm & k8s repos in-sync

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -498,6 +498,17 @@ class Context(WithStatus, Object):
         )
 
     @property
+    def bind_address(self) -> str:
+        """The network binding address from the peer relation."""
+        bind_address = ""
+
+        if self.peer_relation:
+            if binding := self.model.get_binding(self.peer_relation):
+                bind_address = binding.network.bind_address
+
+        return str(bind_address)
+
+    @property
     def clients(self) -> dict[int, ConnectClientContext]:
         """Returns a mapping of integrator relation-id to the related client context."""
         clients = {}

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -10,7 +10,6 @@ import string
 from abc import ABC, abstractmethod
 from typing import BinaryIO, Iterable
 
-from ops import Container
 from ops.pebble import Layer
 
 from literals import CONFIG_DIR, PLUGIN_PATH, SNAP_NAME
@@ -83,7 +82,6 @@ class WorkloadBase(ABC):
     """Base interface for common workload operations."""
 
     paths: Paths = Paths(config_dir=CONFIG_DIR)
-    container: Container
 
     @abstractmethod
     def start(self) -> None:

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -8,8 +8,9 @@ import re
 import secrets
 import string
 from abc import ABC, abstractmethod
-from typing import Iterable
+from typing import BinaryIO, Iterable
 
+from ops import Container
 from ops.pebble import Layer
 
 from literals import CONFIG_DIR, PLUGIN_PATH, SNAP_NAME
@@ -26,6 +27,11 @@ class Paths:
     def snap_dir(self) -> str:
         """Path to Kafka & Kafka connect snap's base dir."""
         return f"/snap/{SNAP_NAME}/current/opt/kafka"
+
+    @property
+    def logs_dir(self) -> str:
+        """Path to logs dir."""
+        return f"/var/snap/{SNAP_NAME}/common/var/log/connect"
 
     @property
     def env(self) -> str:
@@ -77,6 +83,7 @@ class WorkloadBase(ABC):
     """Base interface for common workload operations."""
 
     paths: Paths = Paths(config_dir=CONFIG_DIR)
+    container: Container
 
     @abstractmethod
     def start(self) -> None:
@@ -106,7 +113,7 @@ class WorkloadBase(ABC):
         ...
 
     @abstractmethod
-    def write(self, content: str, path: str, mode: str = "w") -> None:
+    def write(self, content: str | BinaryIO, path: str, mode: str = "w") -> None:
         """Writes content to a workload file.
 
         Args:
@@ -158,7 +165,7 @@ class WorkloadBase(ABC):
         ...
 
     @abstractmethod
-    def remove(self, path: str):
+    def remove(self, path: str, glob: bool = False):
         """Removes the file at the provided path."""
         ...
 

--- a/src/events/connect.py
+++ b/src/events/connect.py
@@ -47,6 +47,7 @@ class ConnectHandler(Object):
         """Handler for `update-status` event."""
         if self.charm.connect_manager.health_check():
             self.charm._set_status(Status.ACTIVE)
+            self.charm.unit.set_ports(self.context.rest_port)
         elif self.context.ready:
             self.charm._set_status(Status.SERVICE_NOT_RUNNING)
         else:
@@ -63,7 +64,6 @@ class ConnectHandler(Object):
         if not self.charm.connect_manager.plugin_path_initiated:
             self.charm.connect_manager.init_plugin_path()
 
-        resource_path = None
         try:
             resource_path = self.model.resources.fetch(PLUGIN_RESOURCE_KEY)
             self.charm.connect_manager.load_plugin(resource_path)
@@ -91,7 +91,7 @@ class ConnectHandler(Object):
         current_config = set(self.charm.workload.read(self.workload.paths.worker_properties))
         diff = set(self.charm.config_manager.properties) ^ current_config
 
-        if not any([diff, resource_path, self.context.worker_unit.should_restart]):
+        if not any([diff, self.context.worker_unit.should_restart]):
             return
 
         if not self.context.ready:

--- a/src/workload.py
+++ b/src/workload.py
@@ -155,7 +155,7 @@ class Workload(WorkloadBase):
             return
 
         for file in _glob.glob(path):
-            self.exec(["rm", file])
+            self.exec(["rm", "-rf", file])
 
     @override
     def check_socket(self, host: str, port: int) -> bool:


### PR DESCRIPTION
This PR syncs `core`, `events` and `managers` code between vm & k8s.

# Changes:
- Added `bind_address` to `Context`
- Added `logs_dir` to `Paths`
- Added `glob` parameter to `WorkloadBase.remove` to add support for path patterns

# Bugfixes:
- Avoid unnecessary restarts when manually attaching plugins