### PR TITLE
[DPE-6744] feat: clean up leftover tasks after connect relation broken

### DIFF
--- a/lib/charms/kafka_connect/v0/integrator.py
+++ b/lib/charms/kafka_connect/v0/integrator.py
@@ -151,7 +151,20 @@ class BasePluginServer(ABC):
 
 
 class ConfigOption(BaseModel):
-    """Model for defining mapping between charm config and connector config."""
+    """Model for defining mapping between charm config and connector config.
+
+    To define a config mapping, following properties could be used:
+
+        json_key (str, required): The counterpart key in connector JSON config. If `mode` is set to "none", this would be ignored and could be set to any arbitrary value.
+        default (Any, required): The default value for this config option.
+        mode (Literal["both", "source", "sink", "none"], optional): Defaults to "both". The expected behaviour of each mode are as following:
+            - both: This config option would be used in both source and sink connector modes.
+            - source: This config option would be used ONLY in source connector mode.
+            - sink: This config option would be used ONLY in sink connector mode.
+            - none: This is not a connector config, but rather a charm config. If set to none, this option would not be used to configure the connector.
+        configurable (bool, optional): Whether this option is configurable via charm config. Defaults to True.
+        description (str, optional): A brief description of this config option, which will be added to the charm's `config.yaml`.
+    """
 
     json_key: str  # Config key in the Task configuration JSON
     default: Any  # Default value
@@ -292,6 +305,7 @@ class ConnectClient:
         auth = HTTPBasicAuth(self.client_context.username, self.client_context.password)
 
         try:
+            # TODO: FIXME: use tls-ca to verify the cert.
             response = requests.request(method, url, verify=False, auth=auth, **kwargs)
         except Exception as e:
             raise ConnectApiError(f"Connect API call /{api} failed: {e}")

--- a/lib/charms/kafka_connect/v0/integrator.py
+++ b/lib/charms/kafka_connect/v0/integrator.py
@@ -459,7 +459,7 @@ class BaseIntegrator(ABC, Object):
     def _peer_relation(self) -> Optional[Relation]:
         """Peer `Relation` object."""
         return self.model.get_relation(self.PEER_REL)
-    
+
     @property
     def _connect_client_relation(self) -> Optional[Relation]:
         """connect-client `Relation` object."""
@@ -500,7 +500,7 @@ class BaseIntegrator(ABC, Object):
         """Returns connectors' unique name used on the REST interface."""
         if not self._connect_client_relation:
             return ""
-        
+
         relation_id = self._connect_client_relation.id
         return f"{self.name}_r{relation_id}_{self.model.uuid.replace('-', '')}"
 

--- a/src/events/connect.py
+++ b/src/events/connect.py
@@ -49,6 +49,7 @@ class ConnectHandler(Object):
         if self.charm.connect_manager.health_check():
             self.charm._set_status(Status.ACTIVE)
             self.charm.unit.set_ports(self.context.rest_port)
+            logger.info(f"Connector(s) Status: {self.charm.connect_manager.connectors}")
         elif self.context.ready:
             self.charm._set_status(Status.SERVICE_NOT_RUNNING)
         else:

--- a/src/literals.py
+++ b/src/literals.py
@@ -39,6 +39,7 @@ PLUGIN_PATH = f"/var/snap/{SNAP_NAME}/common/var/lib/connect/plugins/"
 CONFIG_DIR = f"/var/snap/{SNAP_NAME}/current/etc/connect"
 JMX_EXPORTER_PORT = 9100
 METRICS_RULES_DIR = "./src/alert_rules/prometheus"
+EMPTY_PLUGIN_CHECKSUM = "84ff92691f909a05b224e1c56abb4864f01b4f8e3c854e4bb4c7baf1d3f6d652"
 
 TOPICS = {"offset": "connect-offset", "config": "connect-config", "status": "connect-status"}
 REPLICATION_FACTOR = -1  # -1 uses broker's default replication factor

--- a/src/managers/connect.py
+++ b/src/managers/connect.py
@@ -10,8 +10,10 @@ import re
 import tempfile
 from pathlib import Path
 from subprocess import CalledProcessError
+from typing import Pattern
 
 import requests
+from charms.kafka_connect.v0.integrator import TaskStatus
 from requests.auth import HTTPBasicAuth
 from tenacity import (
     retry,
@@ -25,7 +27,7 @@ from tenacity import (
 
 from core.models import Context
 from core.workload import WorkloadBase
-from literals import GROUP, SUBSTRATE, USER
+from literals import EMPTY_PLUGIN_CHECKSUM, GROUP, SUBSTRATE, USER
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +69,66 @@ class ConnectManager:
             if match := re.search(r"relation-[0-9]+", plugin):
                 cache.add(match.group())
         return cache
+
+    @property
+    def connectors(self) -> dict[str, TaskStatus]:
+        """Returns a mapping of connector names to their status."""
+        if not self.health_check():
+            return {}
+
+        resp = self._request("GET", "/connectors?expand=status").json()
+        # response schema: {connector-name: {status: {connector: {state: STATE}...}...}...}
+        return {
+            k: TaskStatus(v.get("status", {}).get("connector", {}).get("state", "UNKNOWN"))
+            for k, v in resp.items()
+        }
+
+    @staticmethod
+    def _managed_connector_regex(relation_id: int) -> Pattern:
+        """Returns a complied regex pattern matching managed connector names for given `relation_id`.
+
+        Managed connector names should adhere to `.+{RELATION_ID}_{MODEL_UUID}$` regex pattern.
+        """
+        return re.compile(".+?r" + str(relation_id) + "_[0-9a-f]{32}$")
+
+    def _request(
+        self,
+        method: str = "GET",
+        api: str = "",
+        verbose: bool = True,
+        **kwargs,
+    ) -> requests.Response:
+        """Makes a request to Kafka Connect REST endpoint and returns the response.
+
+        Args:
+            method (str, optional): HTTP method. Defaults to "GET".
+            api (str, optional): Specific Kafka Connect API, e.g. "connector-plugins" or "connectors". Defaults to "".
+            verbose (bool, optional): Whether should enable verbose logging or not. Defaults to True.
+            kwargs: Keyword arguments which will be passed to `requests.request` method.
+
+        Raises:
+            ConnectApiError: If the REST API call is unsuccessful.
+
+        Returns:
+            requests.Response: Response object.
+        """
+        auth = HTTPBasicAuth(
+            self.context.peer_workers.ADMIN_USERNAME, self.context.peer_workers.admin_password
+        )
+
+        url = f"{self.context.rest_uri}/{api}"
+
+        try:
+            response = requests.request(
+                method, url, verify=False, auth=auth, timeout=self.REQUEST_TIMEOUT, **kwargs
+            )
+        except Exception as e:
+            raise Exception(f"Connect API call /{api} failed: {e}")
+
+        if verbose:
+            logging.debug(f"{method} - {url}: {response.content}")
+
+        return response
 
     def _plugin_checksum(self, plugin_path: Path) -> str:
         """Calculates checksum of a plugin, currently uses SHA-256 algorithm."""
@@ -137,10 +199,7 @@ class ConnectManager:
         # the checksum here corresponds to a sha256sum of an empty tar files created using --files-from /dev/null
         # this is what is loaded by default as the connect-plugin resource in Charmhub
         # as Charmhub won't allow charms without a resource
-        if (
-            self._plugin_checksum(resource_path)
-            == "84ff92691f909a05b224e1c56abb4864f01b4f8e3c854e4bb4c7baf1d3f6d652"
-        ):
+        if self._plugin_checksum(resource_path) == EMPTY_PLUGIN_CHECKSUM:
             logger.debug("Plugin is empty, skipping...")
             return
 
@@ -163,8 +222,10 @@ class ConnectManager:
                 path = Path(tmp_dir) / "plugin.tar"
                 self._download_plugin(plugin_url, f"{path}")
                 self.load_plugin(path, path_prefix=path_prefix)
+                logger.debug(f"Plugin {plugin_url} loaded successfully.")
         except CalledProcessError as e:
             if "File exists" in e.stderr:
+                logger.debug("Plugin already exists.")
                 return
         except Exception as e:
             raise PluginDownloadFailedError(e)
@@ -177,12 +238,36 @@ class ConnectManager:
 
     def ping_connect_api(self) -> requests.Response:
         """Makes a GET request to the unit's Connect API Endpoint and returns the response."""
-        auth = HTTPBasicAuth(
-            self.context.peer_workers.ADMIN_USERNAME, self.context.peer_workers.admin_password
-        )
-        return requests.get(
-            self.context.rest_uri, timeout=self.REQUEST_TIMEOUT, auth=auth, verify=False
-        )
+        return self._request("GET", "/")
+
+    def connector_status(self, relation_id: int) -> TaskStatus:
+        """Returns the managed connector status for given `relation_id`."""
+        for connector, status in self.connectors.items():
+            if re.match(self._managed_connector_regex(relation_id), connector):
+                return status
+
+        return TaskStatus.UNKNOWN
+
+    def stop_connector(self, relation_id: int) -> None:
+        """Stops the managed connector instance for given `relation_id`."""
+        for connector, status in self.connectors.items():
+            if not re.match(self._managed_connector_regex(relation_id), connector):
+                continue
+
+            if status == TaskStatus.STOPPED:
+                logger.debug("Connector is already stopped.")
+                return
+
+            resp = self._request("PUT", f"connectors/{connector}/stop")
+
+            if resp.status_code == 204:
+                logger.debug(f"Successfully stopped connector for relation ID={relation_id}.")
+                return
+
+            logger.error(f"Unable to stop connector, details: {resp.content}")
+            return
+
+        logger.error(f"Unable to find a managed connector for relation ID={relation_id}")
 
     @retry(
         wait=wait_fixed(3),

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -23,7 +23,7 @@ async def kafka_connect_charm(ops_test: OpsTest):
 @pytest.fixture(scope="module")
 async def source_integrator_charm(ops_test: OpsTest):
     """Build the source (MySQL) integrator charm."""
-    charm_path = "./tests/integration/source-integrator-charm/"
+    charm_path = "./tests/integration/source-integrator-charm"
     charm = await ops_test.build_charm(charm_path)
     return charm
 
@@ -31,7 +31,7 @@ async def source_integrator_charm(ops_test: OpsTest):
 @pytest.fixture(scope="module")
 async def sink_integrator_charm(ops_test: OpsTest):
     """Build the sink (PostgreSQL) integrator charm."""
-    charm_path = "./tests/integration/sink-integrator-charm/"
+    charm_path = "./tests/integration/sink-integrator-charm"
     charm = await ops_test.build_charm(charm_path)
     return charm
 

--- a/tests/integration/sink-integrator-charm/lib/charms/kafka_connect/v0/integrator.py
+++ b/tests/integration/sink-integrator-charm/lib/charms/kafka_connect/v0/integrator.py
@@ -151,7 +151,20 @@ class BasePluginServer(ABC):
 
 
 class ConfigOption(BaseModel):
-    """Model for defining mapping between charm config and connector config."""
+    """Model for defining mapping between charm config and connector config.
+
+    To define a config mapping, following properties could be used:
+
+        json_key (str, required): The counterpart key in connector JSON config. If `mode` is set to "none", this would be ignored and could be set to any arbitrary value.
+        default (Any, required): The default value for this config option.
+        mode (Literal["both", "source", "sink", "none"], optional): Defaults to "both". The expected behaviour of each mode are as following:
+            - both: This config option would be used in both source and sink connector modes.
+            - source: This config option would be used ONLY in source connector mode.
+            - sink: This config option would be used ONLY in sink connector mode.
+            - none: This is not a connector config, but rather a charm config. If set to none, this option would not be used to configure the connector.
+        configurable (bool, optional): Whether this option is configurable via charm config. Defaults to True.
+        description (str, optional): A brief description of this config option, which will be added to the charm's `config.yaml`.
+    """
 
     json_key: str  # Config key in the Task configuration JSON
     default: Any  # Default value
@@ -292,6 +305,7 @@ class ConnectClient:
         auth = HTTPBasicAuth(self.client_context.username, self.client_context.password)
 
         try:
+            # TODO: FIXME: use tls-ca to verify the cert.
             response = requests.request(method, url, verify=False, auth=auth, **kwargs)
         except Exception as e:
             raise ConnectApiError(f"Connect API call /{api} failed: {e}")

--- a/tests/integration/sink-integrator-charm/lib/charms/kafka_connect/v0/integrator.py
+++ b/tests/integration/sink-integrator-charm/lib/charms/kafka_connect/v0/integrator.py
@@ -459,7 +459,7 @@ class BaseIntegrator(ABC, Object):
     def _peer_relation(self) -> Optional[Relation]:
         """Peer `Relation` object."""
         return self.model.get_relation(self.PEER_REL)
-    
+
     @property
     def _connect_client_relation(self) -> Optional[Relation]:
         """connect-client `Relation` object."""
@@ -500,7 +500,7 @@ class BaseIntegrator(ABC, Object):
         """Returns connectors' unique name used on the REST interface."""
         if not self._connect_client_relation:
             return ""
-        
+
         relation_id = self._connect_client_relation.id
         return f"{self.name}_r{relation_id}_{self.model.uuid.replace('-', '')}"
 

--- a/tests/integration/source-integrator-charm/lib/charms/kafka_connect/v0/integrator.py
+++ b/tests/integration/source-integrator-charm/lib/charms/kafka_connect/v0/integrator.py
@@ -151,7 +151,20 @@ class BasePluginServer(ABC):
 
 
 class ConfigOption(BaseModel):
-    """Model for defining mapping between charm config and connector config."""
+    """Model for defining mapping between charm config and connector config.
+
+    To define a config mapping, following properties could be used:
+
+        json_key (str, required): The counterpart key in connector JSON config. If `mode` is set to "none", this would be ignored and could be set to any arbitrary value.
+        default (Any, required): The default value for this config option.
+        mode (Literal["both", "source", "sink", "none"], optional): Defaults to "both". The expected behaviour of each mode are as following:
+            - both: This config option would be used in both source and sink connector modes.
+            - source: This config option would be used ONLY in source connector mode.
+            - sink: This config option would be used ONLY in sink connector mode.
+            - none: This is not a connector config, but rather a charm config. If set to none, this option would not be used to configure the connector.
+        configurable (bool, optional): Whether this option is configurable via charm config. Defaults to True.
+        description (str, optional): A brief description of this config option, which will be added to the charm's `config.yaml`.
+    """
 
     json_key: str  # Config key in the Task configuration JSON
     default: Any  # Default value
@@ -292,6 +305,7 @@ class ConnectClient:
         auth = HTTPBasicAuth(self.client_context.username, self.client_context.password)
 
         try:
+            # TODO: FIXME: use tls-ca to verify the cert.
             response = requests.request(method, url, verify=False, auth=auth, **kwargs)
         except Exception as e:
             raise ConnectApiError(f"Connect API call /{api} failed: {e}")

--- a/tests/integration/source-integrator-charm/lib/charms/kafka_connect/v0/integrator.py
+++ b/tests/integration/source-integrator-charm/lib/charms/kafka_connect/v0/integrator.py
@@ -459,7 +459,7 @@ class BaseIntegrator(ABC, Object):
     def _peer_relation(self) -> Optional[Relation]:
         """Peer `Relation` object."""
         return self.model.get_relation(self.PEER_REL)
-    
+
     @property
     def _connect_client_relation(self) -> Optional[Relation]:
         """connect-client `Relation` object."""
@@ -500,7 +500,7 @@ class BaseIntegrator(ABC, Object):
         """Returns connectors' unique name used on the REST interface."""
         if not self._connect_client_relation:
             return ""
-        
+
         relation_id = self._connect_client_relation.id
         return f"{self.name}_r{relation_id}_{self.model.uuid.replace('-', '')}"
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,7 +4,7 @@
 
 from collections import defaultdict
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import yaml
@@ -86,7 +86,13 @@ def plugin_resource():
 
 @pytest.fixture(scope="module")
 def active_service():
-    with patch(
-        "managers.connect.ConnectManager.health_check", return_value=True
-    ) as patched_service:
+    mock_response = MagicMock()
+    mock_response.json.return_value = {}
+
+    with (
+        patch(
+            "managers.connect.ConnectManager.health_check", return_value=True
+        ) as patched_service,
+        patch("managers.connect.ConnectManager._request", return_value=mock_response),
+    ):
         yield patched_service

--- a/tests/unit/data/status_response.json
+++ b/tests/unit/data/status_response.json
@@ -1,0 +1,41 @@
+{
+    "mysql-source-integrator_r12_1129a534a92e46658fa1f1c9743a7c11": {
+        "status": {
+            "name": "mysql-source-integrator_r12_1129a534a92e46658fa1f1c9743a7c11",
+            "connector": {
+                "state": "RUNNING",
+                "worker_id": "10.150.221.155:8083"
+            },
+            "tasks": [
+                {
+                    "id": 0,
+                    "state": "RUNNING",
+                    "worker_id": "10.150.221.155:8083"
+                }
+            ],
+            "type": "source"
+        }
+    },
+    "custom-connector": {
+        "status": {
+            "name": "custom-connector",
+            "connector": {
+                "state": "STOPPED",
+                "worker_id": "10.150.221.155:8083"
+            },
+            "tasks": [],
+            "type": "source"
+        }
+    },
+    "mysql-source-integrator_r11_1129a534a92e46658fa1f1c9743a7c11": {
+        "status": {
+            "name": "mysql-source-integrator_r11_1129a534a92e46658fa1f1c9743a7c11",
+            "connector": {
+                "state": "STOPPED",
+                "worker_id": "10.150.221.155:8083"
+            },
+            "tasks": [],
+            "type": "sink"
+        }
+    }
+}

--- a/tests/unit/test_connect_manager.py
+++ b/tests/unit/test_connect_manager.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+import logging
+import random
+import re
+import subprocess
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from src.core.models import Context
+from src.core.workload import WorkloadBase
+from src.literals import EMPTY_PLUGIN_CHECKSUM
+from src.managers.connect import ConnectManager, PluginDownloadFailedError
+
+logger = logging.getLogger(__name__)
+
+
+STATUS_RESPONSE = json.load(open("./tests/unit/data/status_response.json", "r"))
+
+
+class FakeDir:
+    """Fake directory object, usable as return value for `os.scandir`."""
+
+    def __init__(self, name):
+        self.name = name
+
+    def is_dir(self) -> bool:
+        return True
+
+
+@pytest.fixture()
+def connect_manager(monkeypatch: pytest.MonkeyPatch):
+    """A ConnectManager instance with mock `Workload` and `Context`."""
+    mock_workload = MagicMock(spec=WorkloadBase)
+    mock_context = MagicMock(spec=Context)
+
+    hash1 = f"{random.getrandbits(256):032x}"
+    hash2 = f"{random.getrandbits(256):032x}"
+
+    # TODO: we should probably move all `os` dependencies
+    # from the manager to workload and get rid of monkeypatchs here.
+    monkeypatch.setattr(
+        "os.scandir",
+        lambda _: [
+            FakeDir("plugin-a"),
+            FakeDir(f"relation-1-{hash1}"),
+            FakeDir("plugin-b"),
+            FakeDir(f"relation-7-{hash2}"),
+        ],
+    )
+    monkeypatch.setattr("os.path.exists", lambda: True)
+
+    mgr = ConnectManager(context=mock_context, workload=mock_workload)
+    yield mgr
+
+    monkeypatch.undo()
+
+
+def test_loaded_client_plugins(connect_manager: ConnectManager) -> None:
+    """Checks ConnectManager appropriately distinguishes client plugins from user provided plugins."""
+    assert connect_manager.loaded_client_plugins == {"relation-1", "relation-7"}
+
+
+@pytest.mark.parametrize(
+    "test_data",
+    [
+        ("connector", False),
+        ("my-app", False),
+        (f"long-connector-name-r11_{uuid.uuid4().hex}", True),
+        (f"app-r11_{uuid.uuid4().hex}", True),
+        (uuid.uuid4().hex, False),
+    ],
+)
+def test_managed_connector_regexes(
+    connect_manager: ConnectManager, test_data: tuple[str, bool]
+) -> None:
+    """Checks ConnectManager appropriately distinguishes integrator-managed connectors from the custom, user-defined ones."""
+    assert (
+        bool(re.match(connect_manager._managed_connector_regex(11), test_data[0])) == test_data[1]
+    )
+    # check we don't mix up `r11_uuid` with `r1_uuid`
+    assert not bool(re.match(connect_manager._managed_connector_regex(1), test_data[0]))
+
+
+def test_connect_manager_request(connect_manager: ConnectManager) -> None:
+    """Tests ConnectManager._request basic functionality."""
+    with patch("requests.request", return_value=MagicMock()) as fake_request:
+        connect_manager.context.rest_uri = "http://some-url:8083"
+        connect_manager._request("GET", "/")
+
+    assert fake_request.call_args[0][0] == "GET"
+    assert str(fake_request.call_args[0][1]).startswith("http://some-url:8083")
+    assert fake_request.call_args[1].get("timeout") == connect_manager.REQUEST_TIMEOUT
+
+
+def test_untar_plugin(connect_manager: ConnectManager) -> None:
+    """Tests ConnectManager._untar_plugin functionality."""
+    connect_manager._untar_plugin(Path("/path/to/plugin.tar.gz"), Path("/path/to/var/plugins/"))
+    assert " ".join(connect_manager.workload.exec.call_args[0][0]).startswith("tar -xvzf")
+
+    connect_manager._untar_plugin(Path("/path/to/plugin.tar"), Path("/path/to/var/plugins/"))
+    assert " ".join(connect_manager.workload.exec.call_args[0][0]).startswith("tar -xvf")
+
+    connect_manager._untar_plugin(Path("/path/to/plugin"), Path("/path/to/var/plugins/"))
+    assert " ".join(connect_manager.workload.exec.call_args[0][0]).startswith("tar -xvf")
+
+
+def test_attach_empty_plugin(
+    connect_manager: ConnectManager, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Tests attaching an empty TAR file leads to no-op, followed by a log message by ConnectManager."""
+    caplog.set_level(logging.DEBUG)
+    connect_manager._plugin_checksum = (
+        lambda _: subprocess.check_output(  # pyright: ignore[reportAttributeAccessIssue]
+            "sha256sum ./empty.tar", shell=True, universal_newlines=True
+        )
+        .strip()
+        .split()[0]
+    )
+    assert connect_manager._plugin_checksum(Path("emptyfile")) == EMPTY_PLUGIN_CHECKSUM
+    connect_manager.load_plugin(Path("./empty.tar"))
+    assert "Plugin is empty, skipping..." in caplog.messages
+
+
+@pytest.mark.parametrize("with_connection_error", [True, False])
+@pytest.mark.parametrize("directory_exists", [True, False])
+def test_load_plugin_from_url(
+    connect_manager: ConnectManager,
+    with_connection_error: bool,
+    directory_exists: bool,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Checks `load_plugin_from_url` method functionality under different conditions."""
+
+    def _mock_get(*args, **kwargs):
+        if with_connection_error:
+            raise ConnectionError("Connection Error")
+
+        fake_response = MagicMock()
+        fake_response.iter_content.return_value = [b"chunk1", b"chunk2", b"chunk3"]
+        return fake_response
+
+    def _mock_mkdir(*args, **kwargs):
+        # This is to simulate file exists exception.
+        subprocess.check_output(
+            "mkdir ./tests", shell=True, stderr=subprocess.PIPE, universal_newlines=True
+        )
+
+    # we need to undo monkeypatch here since `tempfile` needs `os.scandir`.
+    monkeypatch.undo()
+    # instead, we'll patch the `reload_plugins` method for this particular test.
+    connect_manager.reload_plugins = lambda: None
+
+    fake_url = "http://some-plugin-url"
+    with monkeypatch.context() as m:
+        m.setattr("requests.get", _mock_get)
+        caplog.set_level(logging.DEBUG)
+
+        if not any([with_connection_error, directory_exists]):
+            connect_manager.load_plugin_from_url(fake_url)
+            assert f"Plugin {fake_url} loaded successfully." in caplog.messages
+            return
+
+        if with_connection_error:
+            with pytest.raises(PluginDownloadFailedError):
+                connect_manager.load_plugin_from_url(fake_url)
+            return
+
+        # plugin exists!
+        connect_manager.workload.mkdir = _mock_mkdir
+        connect_manager.load_plugin_from_url(fake_url)
+        assert "Plugin already exists." in caplog.messages
+
+
+@pytest.mark.parametrize("healthy", [True, False])
+def test_connector_lifecycle_management(
+    connect_manager: ConnectManager, healthy: bool, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Tests `connector_status` and `stop_connector` methods used for connector lifecycle management."""
+    with patch("requests.request") as _fake_request:
+        connect_manager.health_check = lambda: healthy
+        response = MagicMock()
+        response.json.return_value = STATUS_RESPONSE
+        _fake_request.return_value = response
+
+        if not healthy:
+            assert not connect_manager.connectors
+            return
+        else:
+            assert len(connect_manager.connectors) == 3
+
+        expected_status = {1: "UNKNOWN", 11: "STOPPED", 12: "RUNNING"}
+
+        response.status_code = 204
+        for rel_id in (1, 11):
+            assert connect_manager.connector_status(rel_id).value == expected_status[rel_id]
+            connect_manager.stop_connector(rel_id)
+
+        assert connect_manager.connector_status(12).value == expected_status[12]
+
+        connect_manager.stop_connector(12)
+        assert caplog.messages[-1] == "Successfully stopped connector for relation ID=12."
+
+        response.status_code = 500
+        connect_manager.stop_connector(12)
+        assert caplog.messages[-1].startswith("Unable to stop connector, details:")
+
+
+@pytest.mark.parametrize("status_code", (200, 500))
+@pytest.mark.parametrize("bad_response", [True, False])
+def test_health_check(
+    connect_manager: ConnectManager, status_code: int, bad_response: bool
+) -> None:
+    """Tests ConnectManager health checking functionality."""
+    with patch("requests.request") as _fake_request:
+        response = MagicMock()
+        response.status_code = status_code
+        response.json.return_value = (
+            {}
+            if status_code != 200 or bad_response
+            else {"kafka_cluster_id": "unique-id", "version": "3.9.0-ubuntu1"}
+        )
+        _fake_request.return_value = response
+
+        assert connect_manager.health_check() == (status_code == 200 and not bad_response)

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -149,7 +149,9 @@ def test_upgrade_sets_failed_if_failed_upgrade_check(
     assert patch_set_failed.call_count
 
 
-def test_upgrade_succeeds(ctx: Context, base_state: State, upgrade_func: str) -> None:
+def test_upgrade_succeeds(
+    ctx: Context, base_state: State, upgrade_func: str, active_service
+) -> None:
     # Given
     state_in = base_state
 
@@ -159,7 +161,6 @@ def test_upgrade_succeeds(ctx: Context, base_state: State, upgrade_func: str) ->
         patch("workload.Workload.start") as patched_start,
         patch("workload.Workload.stop"),
         patch("workload.Workload.install"),
-        patch("managers.connect.ConnectManager.health_check", return_value=True),
         patch("core.models.Context.ready", return_value=True),
         patch(
             "events.upgrade.ConnectUpgrade.set_unit_completed",
@@ -176,7 +177,7 @@ def test_upgrade_succeeds(ctx: Context, base_state: State, upgrade_func: str) ->
 
 @pytest.mark.skipif(SUBSTRATE == "k8s", reason="Upgrade granted not used on K8s charms")
 def test_upgrade_granted_recurses_upgrade_changed_on_leader(
-    ctx: Context, base_state: State
+    ctx: Context, base_state: State, active_service
 ) -> None:
     # Given
     state_in = base_state
@@ -187,7 +188,6 @@ def test_upgrade_granted_recurses_upgrade_changed_on_leader(
         patch("workload.Workload.start"),
         patch("workload.Workload.stop"),
         patch("workload.Workload.install"),
-        patch("managers.connect.ConnectManager.health_check", return_value=True),
         patch("core.models.Context.ready", return_value=True),
         patch(
             "events.upgrade.ConnectUpgrade.on_upgrade_changed", autospec=True


### PR DESCRIPTION
This PR is the companion to [template charm PR](https://github.com/canonical/template-connect-integrator/pull/3/files). Since there's no stable way to stop connector on requirer side during `RelationDeparted` on scenarios like Kafka Connect scale-in, the logic is implemented here.

# Changes:
- Update `kafka_connect` lib
- Added connector lifecycle management methods to `ConnectManager`
- Stop connectors on `connect-client-relation-broken`
- Improve unit test coverage for `managers/connect.py`