### PR TITLE
[DPE-6743] - chore: handle PLUGIN_URL_NOT_REQUIRED

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - fix-release
 
 jobs:
   ci-tests:
@@ -20,10 +21,11 @@ jobs:
     name: Release charm
     needs:
       - ci-tests
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v29.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@29.3.0-rc.1
     with:
-      channel: 3/edge
+      channel: latest/edge
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
+      path-to-file-resource: ./empty.tar
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -301,6 +301,7 @@ from enum import Enum
 from typing import (
     Callable,
     Dict,
+    Final,
     ItemsView,
     KeysView,
     List,
@@ -3599,6 +3600,8 @@ class KafkaConnectProvides(KafkaConnectProviderData, KafkaConnectProviderEventHa
         KafkaConnectProviderData.__init__(self, charm.model, relation_name)
         KafkaConnectProviderEventHandlers.__init__(self, charm, self)
 
+# Sentinel value passed from Kafka Connect requirer side when it does not need to serve any plugins.
+PLUGIN_URL_NOT_REQUIRED: Final[str] = "NOT-REQUIRED"
 
 class KafkaConnectRequirerData(RequirerData):
     """Requirer-side of the Kafka Connect relation."""

--- a/src/events/connect.py
+++ b/src/events/connect.py
@@ -8,6 +8,7 @@ import datetime
 import logging
 from typing import TYPE_CHECKING
 
+from charms.data_platform_libs.v0.data_interfaces import PLUGIN_URL_NOT_REQUIRED
 from ops import ModelError
 from ops.charm import (
     ConfigChangedEvent,
@@ -131,7 +132,10 @@ class ConnectHandler(Object):
                 )
                 continue
 
-            if client.username not in loaded_plugins:
+            if (
+                client.username not in loaded_plugins
+                and client.plugin_url != PLUGIN_URL_NOT_REQUIRED
+            ):
                 continue
 
             if set(client.endpoints.split(",")) == set(self.context.rest_endpoints.split(",")):
@@ -155,7 +159,7 @@ class ConnectHandler(Object):
         update_set = set()
 
         for client in self.context.clients.values():
-            if client.username in loaded_clients:
+            if client.username in loaded_clients or client.plugin_url == PLUGIN_URL_NOT_REQUIRED:
                 continue
 
             try:

--- a/src/events/provider.py
+++ b/src/events/provider.py
@@ -8,6 +8,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from charms.data_platform_libs.v0.data_interfaces import (
+    PLUGIN_URL_NOT_REQUIRED,
     IntegrationRequestedEvent,
     KafkaConnectProviderEventHandlers,
 )
@@ -59,17 +60,14 @@ class ConnectProvider(Object):
             event.defer()
             return
 
-        if not client.plugin_url:
-            event.defer()
-            return
-
-        try:
-            self.charm.connect_manager.load_plugin_from_url(
-                client.plugin_url, path_prefix=client.username
-            )
-        except PluginDownloadFailedError as e:
-            logger.error(f"Unable to fetch the plugin: {e}")
-            return
+        if client.plugin_url != PLUGIN_URL_NOT_REQUIRED:
+            try:
+                self.charm.connect_manager.load_plugin_from_url(
+                    client.plugin_url, path_prefix=client.username
+                )
+            except PluginDownloadFailedError as e:
+                logger.error(f"Unable to fetch the plugin: {e}")
+                return
 
         if not self.charm.unit.is_leader():
             return

--- a/tests/unit/test_connect.py
+++ b/tests/unit/test_connect.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import dataclasses
+import logging
+from typing import cast
+from unittest.mock import PropertyMock, patch
+
+import pytest
+from charms.data_platform_libs.v0.data_interfaces import PLUGIN_URL_NOT_REQUIRED
+from ops.testing import Context, PeerRelation, Relation, State
+from src.charm import ConnectCharm
+from src.literals import CLIENT_REL, PEER_REL
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize(
+    "plugin_url",
+    [PLUGIN_URL_NOT_REQUIRED, "mellon"],
+    ids=[f"plugin_url {PLUGIN_URL_NOT_REQUIRED}", "pugin_url"],
+)
+def test_update_plugins(ctx: Context, base_state: State, plugin_url) -> None:
+    f"""Test update_plugins does not attempt to load plugin from url if {PLUGIN_URL_NOT_REQUIRED}"""
+    # Given
+    relation_id = 7
+    state_in = base_state
+    client_rel = Relation(
+        CLIENT_REL,
+        CLIENT_REL,
+        id=relation_id,
+        remote_app_data={"plugin-url": plugin_url},
+    )
+    peer_rel = PeerRelation(PEER_REL, PEER_REL, local_app_data={})
+    state_in = dataclasses.replace(base_state, relations=[peer_rel, client_rel])
+
+    # When
+    with (
+        ctx(ctx.on.config_changed(), state_in) as manager,
+        patch("managers.connect.ConnectManager.load_plugin_from_url") as patched_load_plugin,
+    ):
+        _ = cast(ConnectCharm, manager.charm)
+        manager.charm.connect.update_plugins()
+
+        # Then
+        if plugin_url == PLUGIN_URL_NOT_REQUIRED:
+            assert not patched_load_plugin.call_count
+        else:
+            assert patched_load_plugin.call_count
+
+
+@pytest.mark.parametrize(
+    "plugin_url",
+    [PLUGIN_URL_NOT_REQUIRED, "mellon"],
+    ids=[f"plugin_url {PLUGIN_URL_NOT_REQUIRED}", "pugin_url missing username"],
+)
+def test_config_changed_update_clients_data(ctx: Context, base_state: State, plugin_url) -> None:
+    """Checks config-changed updates client relation data without plugin-url set."""
+    # Given
+    relation_id = 7
+    state_in = base_state
+    client_rel = Relation(
+        CLIENT_REL,
+        CLIENT_REL,
+        id=relation_id,
+        remote_app_data={"plugin-url": plugin_url},
+    )
+    peer_rel = PeerRelation(PEER_REL, PEER_REL, local_app_data={})
+    state_in = dataclasses.replace(base_state, relations=[peer_rel, client_rel])
+
+    # When
+    with (
+        patch("core.models.RelationContext.update") as patched_update,
+        patch(
+            "core.models.ConnectClientContext.password",
+            new_callable=PropertyMock,
+            return_value="mellon",
+        ),
+    ):
+        _ = ctx.run(ctx.on.config_changed(), state_in)
+
+        # Then
+        if plugin_url == PLUGIN_URL_NOT_REQUIRED:
+            assert patched_update.call_count
+        else:
+            assert not patched_update.call_count


### PR DESCRIPTION
## Changes Made
#### `chore: handle PLUGIN_URL_NOT_REQUIRED`
- Skip loading plugins if string is passed across the client relation in `plugin-url`
- Continue to update clients, even if 'not needed' plugin is not in the plugin cache 