### PR TITLE
[DPE-6471] feat: add opinionated config options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 .python-version
 last_written_value
 nohup.out
+.local/

--- a/config.yaml
+++ b/config.yaml
@@ -2,8 +2,48 @@
 # See LICENSE file for licensing details.
 
 options:
+  profile:
+    description: |
+      Profile representing the scope of deployment, and used to enable high-level customisation of 
+      configs, resource checks/allocation, logging levels, etc. 
+      
+      Allowed values are: "production" and "testing".
+    type: string
+    default: production
   rest_port:
     description: |
       Port used for Apache Kafka Connect REST API endpoint.
     type: int
     default: 8083
+  key_converter:
+    description: |
+      Converter class used to convert between Kafka Connect format and the serialized form that
+      is written to Kafka. This controls the format of the keys in messages written to or read 
+      from Kafka, and since this is independent of connectors, it allows any connector to work 
+      with any serialization format. Examples of common formats include JSON and Avro.
+      
+      Note: For custom converters, the library files should be provided to the charm beforehand
+      using `juju attach-resource` command. Please refer to the docs for more details.
+    type: string
+    default: org.apache.kafka.connect.json.JsonConverter
+  value_converter:
+    description: |
+      Converter class used to convert between Kafka Connect format and the serialized form that 
+      is written to Kafka. This controls the format of the values in messages written to or read 
+      from Kafka, and since this is independent of connectors, it allows any connector to work 
+      with any serialization format. Examples of common formats include JSON and Avro.
+
+      Note: For custom converters, the library files should be provided to the charm beforehand
+      using `juju attach-resource` command. Please refer to the docs for more details.
+    type: string
+    default: org.apache.kafka.connect.json.JsonConverter
+  exactly_once_source_support:
+    description: |
+      Whether to enable exactly-once support for source connectors in the cluster by using 
+      transactions to write source records and their source offsets, and by proactively 
+      fencing out old task generations before bringing up new ones.
+      
+      Allowed values are: "enabled" and "disabled".
+    type: string
+    default: disabled
+ 

--- a/config.yaml
+++ b/config.yaml
@@ -6,11 +6,9 @@ options:
     description: |
       Whether to enable exactly-once support for source connectors in the cluster by using 
       transactions to write source records and their source offsets, and by proactively 
-      fencing out old task generations before bringing up new ones.
-      
-      Allowed values are: "enabled" and "disabled".
-    type: string
-    default: disabled
+      fencing out old task generations before bringing up new ones.      
+    type: boolean
+    default: false
   key_converter:
     description: |
       Converter class used to convert between Kafka Connect format and the serialized form that

--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,33 @@
 # See LICENSE file for licensing details.
 
 options:
+  exactly_once_source_support:
+    description: |
+      Whether to enable exactly-once support for source connectors in the cluster by using 
+      transactions to write source records and their source offsets, and by proactively 
+      fencing out old task generations before bringing up new ones.
+      
+      Allowed values are: "enabled" and "disabled".
+    type: string
+    default: disabled
+  key_converter:
+    description: |
+      Converter class used to convert between Kafka Connect format and the serialized form that
+      is written to Kafka. This controls the format of the keys in messages written to or read 
+      from Kafka, and since this is independent of connectors, it allows any connector to work 
+      with any serialization format. Examples of common formats include JSON and Avro.
+      
+      Note: For custom converters, the library files should be provided to the charm beforehand
+      using `juju attach-resource` command. Please refer to the docs for more details.
+    type: string
+    default: org.apache.kafka.connect.json.JsonConverter
+  log_level:
+    description: |
+      Level of logging for the Apache Kafka Connect service operated by the charm. 
+
+      Allowed values are: "ERROR", "WARNING", "INFO", and "DEBUG".
+    type: string
+    default: "INFO"
   profile:
     description: |
       Profile representing the scope of deployment, and used to enable high-level customisation of 
@@ -15,17 +42,6 @@ options:
       Port used for Apache Kafka Connect REST API endpoint.
     type: int
     default: 8083
-  key_converter:
-    description: |
-      Converter class used to convert between Kafka Connect format and the serialized form that
-      is written to Kafka. This controls the format of the keys in messages written to or read 
-      from Kafka, and since this is independent of connectors, it allows any connector to work 
-      with any serialization format. Examples of common formats include JSON and Avro.
-      
-      Note: For custom converters, the library files should be provided to the charm beforehand
-      using `juju attach-resource` command. Please refer to the docs for more details.
-    type: string
-    default: org.apache.kafka.connect.json.JsonConverter
   value_converter:
     description: |
       Converter class used to convert between Kafka Connect format and the serialized form that 
@@ -37,13 +53,4 @@ options:
       using `juju attach-resource` command. Please refer to the docs for more details.
     type: string
     default: org.apache.kafka.connect.json.JsonConverter
-  exactly_once_source_support:
-    description: |
-      Whether to enable exactly-once support for source connectors in the cluster by using 
-      transactions to write source records and their source offsets, and by proactively 
-      fencing out old task generations before bringing up new ones.
-      
-      Allowed values are: "enabled" and "disabled".
-    type: string
-    default: disabled
  

--- a/src/charm.py
+++ b/src/charm.py
@@ -30,7 +30,7 @@ from literals import (
     PLUGIN_RESOURCE_KEY,
     SNAP_NAME,
     SUBSTRATE,
-    DebugLevel,
+    LogLevel,
     Status,
     Substrates,
 )
@@ -54,7 +54,7 @@ class ConnectCharm(TypedCharmBase[CharmConfig]):
         self.substrate: Substrates = SUBSTRATE
         self.pending_inactive_statuses: list[Status] = []
 
-        self.workload = Workload()
+        self.workload = Workload(profile=self.config.profile)
         self.context = Context(self, substrate=SUBSTRATE)
         self.auth_manager = AuthManager(
             context=self.context, workload=self.workload, store_path=self.workload.paths.passwords
@@ -110,7 +110,7 @@ class ConnectCharm(TypedCharmBase[CharmConfig]):
     def _set_status(self, key: Status) -> None:
         """Sets charm status."""
         status: StatusBase = key.value.status
-        log_level: DebugLevel = key.value.log_level
+        log_level: LogLevel = key.value.log_level
 
         getattr(logger, log_level.lower())(status.message)
         self.pending_inactive_statuses.append(key)

--- a/src/core/structured_config.py
+++ b/src/core/structured_config.py
@@ -5,6 +5,7 @@
 """Structured configuration for the Kafka Connect charm."""
 import logging
 from enum import Enum
+from typing import Literal
 
 from charms.data_platform_libs.v0.data_models import BaseConfigModel
 from pydantic import validator
@@ -24,7 +25,11 @@ class LogLevel(str, Enum):
 class CharmConfig(BaseConfigModel):
     """Manager for the structured configuration."""
 
+    exactly_once_source_support: Literal["disabled", "enabled"]
+    key_converter: str
+    profile: Literal["testing", "production"]
     rest_port: int
+    value_converter: str
 
     @validator("*", pre=True)
     @classmethod

--- a/src/core/structured_config.py
+++ b/src/core/structured_config.py
@@ -4,22 +4,14 @@
 
 """Structured configuration for the Kafka Connect charm."""
 import logging
-from enum import Enum
 from typing import Literal
 
 from charms.data_platform_libs.v0.data_models import BaseConfigModel
 from pydantic import validator
 
+from literals import CharmProfile, LogLevel
+
 logger = logging.getLogger(__name__)
-
-
-class LogLevel(str, Enum):
-    """Enum for the `log_level` field."""
-
-    INFO = "INFO"
-    WARNING = "WARNING"
-    ERROR = "ERROR"
-    DEBUG = "DEBUG"
 
 
 class CharmConfig(BaseConfigModel):
@@ -27,7 +19,8 @@ class CharmConfig(BaseConfigModel):
 
     exactly_once_source_support: Literal["disabled", "enabled"]
     key_converter: str
-    profile: Literal["testing", "production"]
+    log_level: LogLevel
+    profile: CharmProfile
     rest_port: int
     value_converter: str
 

--- a/src/core/structured_config.py
+++ b/src/core/structured_config.py
@@ -4,7 +4,6 @@
 
 """Structured configuration for the Kafka Connect charm."""
 import logging
-from typing import Literal
 
 from charms.data_platform_libs.v0.data_models import BaseConfigModel
 from pydantic import validator
@@ -17,7 +16,7 @@ logger = logging.getLogger(__name__)
 class CharmConfig(BaseConfigModel):
     """Manager for the structured configuration."""
 
-    exactly_once_source_support: Literal["disabled", "enabled"]
+    exactly_once_source_support: bool
     key_converter: str
     log_level: LogLevel
     profile: CharmProfile

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -86,6 +86,11 @@ class Paths:
         """Path to JMX Prometheus exporter YAML config file."""
         return f"{self.config_dir}/jmx_prometheus.yaml"
 
+    @property
+    def log4j_properties(self) -> str:
+        """Path to log4j properties file."""
+        return f"{self.config_dir}/log4j.properties"
+
 
 class WorkloadBase(ABC):
     """Base interface for common workload operations."""

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -8,11 +8,20 @@ import re
 import secrets
 import string
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import BinaryIO, Iterable
 
 from ops.pebble import Layer
 
 from literals import CONFIG_DIR, PLUGIN_PATH, SNAP_NAME
+
+
+@dataclass
+class DirEntry:
+    """Object to represent an entry in directory listing."""
+
+    name: str
+    is_dir: bool
 
 
 class Paths:
@@ -153,18 +162,28 @@ class WorkloadBase(ABC):
         ...
 
     @abstractmethod
-    def mkdir(self, path: str):
+    def mkdir(self, path: str) -> None:
         """Creates a new directory at the provided path."""
         ...
 
     @abstractmethod
-    def rmdir(self, path: str):
+    def rmdir(self, path: str) -> None:
         """Removes the directory at the provided path."""
         ...
 
     @abstractmethod
-    def remove(self, path: str, glob: bool = False):
+    def remove(self, path: str, glob: bool = False) -> None:
         """Removes the file at the provided path."""
+        ...
+
+    @abstractmethod
+    def dir_exists(self, path: str) -> bool:
+        """Checks whether a directory exists at provided path on the workload."""
+        ...
+
+    @abstractmethod
+    def ls(self, path: str) -> list[DirEntry]:
+        """Returns a directory listing of provided path on the workload."""
         ...
 
     @abstractmethod

--- a/src/events/connect.py
+++ b/src/events/connect.py
@@ -4,19 +4,17 @@
 
 """Event Handler for Kafka Connect related events."""
 
-import datetime
 import logging
 from typing import TYPE_CHECKING
 
 from charms.data_platform_libs.v0.data_interfaces import PLUGIN_URL_NOT_REQUIRED
-from ops import ModelError
 from ops.charm import (
     ConfigChangedEvent,
 )
 from ops.framework import EventBase, Object
 
 from events.provider import ConnectProvider
-from literals import PEER_REL, PLUGIN_RESOURCE_KEY, Status
+from literals import PEER_REL, Status
 from managers.connect import PluginDownloadFailedError
 
 if TYPE_CHECKING:
@@ -63,47 +61,15 @@ class ConnectHandler(Object):
 
     def _on_config_changed(self, event: ConfigChangedEvent) -> None:
         """Handler for `config-changed` event."""
-        if not self.charm.connect_manager.plugin_path_initiated:
-            self.charm.connect_manager.init_plugin_path()
-
-        try:
-            resource_path = self.model.resources.fetch(PLUGIN_RESOURCE_KEY)
-            self.charm.connect_manager.load_plugin(resource_path)
-        except RuntimeError:
-            logger.error(f"Resource {PLUGIN_RESOURCE_KEY} not defined in the charm build.")
-        except (NameError, ModelError):
-            logger.debug(
-                f"Resource {PLUGIN_RESOURCE_KEY} not found or could not be downloaded, skipping plugin loading."
-            )
-
-        self.update_plugins()
-        self.update_clients_data()
-
-        if self.context.peer_workers.tls_enabled and self.charm.tls_manager.sans_change_detected:
-            self.charm.tls.certificates.on.certificate_expiring.emit(
-                certificate=self.unit_tls_context.certificate,
-                expiry=datetime.datetime.now().isoformat(),
-            )
-            self.charm.context.worker_unit.update(
-                {self.unit_tls_context.CERT: ""}
-            )  # ensures only single requested new certs, will be replaced on new certificate-available event
-
-            return  # config-changed would be eventually fired on certificate-available, so no need to defer.
-
-        current_config = set(self.charm.workload.read(self.workload.paths.worker_properties))
-        diff = set(self.charm.config_manager.properties) ^ current_config
-
-        if not any([diff, self.context.worker_unit.should_restart]):
-            return
-
-        if not self.context.ready:
-            self.charm._set_status(self.context.status)
+        if not self.workload.container_can_connect:
             event.defer()
             return
 
-        self.enable_auth()
-        self.charm.config_manager.configure()
-        self.charm.connect_manager.restart_worker()
+        self.charm.reconcile()
+
+        if not self.context.ready:
+            event.defer()
+            return
 
         self._update_status(event)
 

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -109,13 +109,7 @@ class TLSHandler(Object):
             }
         )
 
-        self.charm.tls_manager.set_server_key()
-        self.charm.tls_manager.set_ca()
-        self.charm.tls_manager.set_certificate()
-        self.charm.tls_manager.set_chain()
-        self.charm.tls_manager.set_bundle()
-        self.charm.tls_manager.set_truststore()
-        self.charm.tls_manager.set_keystore()
+        self.charm.tls_manager.configure()
 
         self.charm.on.config_changed.emit()
 

--- a/src/literals.py
+++ b/src/literals.py
@@ -50,10 +50,8 @@ PEER_REL = "worker"
 CLIENT_REL = "connect-client"
 TLS_REL = "certificates"
 
-# TODO: this should be set using `profile` config option in the future
-LOG_SENSITIVE_OUTPUT = True  # set False for production mode & builds
-
-DebugLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR"]
+CharmProfile = Literal["testing", "production"]
+LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR"]
 DatabagScope = Literal["unit", "app"]
 Substrates = Literal["vm", "k8s"]
 ClientModes = Literal["worker", "producer", "consumer"]
@@ -66,7 +64,7 @@ class StatusLevel:
     """Status object helper."""
 
     status: StatusBase
-    log_level: DebugLevel
+    log_level: LogLevel
 
 
 class Status(Enum):

--- a/src/managers/connect.py
+++ b/src/managers/connect.py
@@ -58,7 +58,7 @@ class ConnectManager:
     @property
     def plugin_path_initiated(self) -> bool:
         """Checks whether plugin path is initiated or not."""
-        return os.path.exists(self.workload.paths.plugins)
+        return self.workload.dir_exists(self.workload.paths.plugins)
 
     @property
     def loaded_client_plugins(self) -> set:
@@ -177,8 +177,8 @@ class ConnectManager:
         try:
             self._plugins_cache = {
                 f.name
-                for f in os.scandir(self.workload.paths.plugins)
-                if f.is_dir() and not f.name.startswith(".")
+                for f in self.workload.ls(self.workload.paths.plugins)
+                if f.is_dir and not f.name.startswith(".")
             }
         except FileNotFoundError:  # possibly since plugins folder not created yet.
             return

--- a/src/workload.py
+++ b/src/workload.py
@@ -161,7 +161,7 @@ class Workload(WorkloadBase):
 
     @override
     def dir_exists(self, path: str) -> bool:
-        return os.path.exists(path)
+        return os.path.isdir(path)
 
     @override
     def ls(self, path: str) -> list[DirEntry]:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -31,6 +31,7 @@ async def test_deploy_charms(ops_test: OpsTest, kafka_connect_charm):
             application_name=APP_NAME,
             num_units=1,
             series="jammy",
+            config={"profile": "testing"},
         ),
         ops_test.model.deploy(
             KAFKA_APP,

--- a/tests/integration/test_plugins.py
+++ b/tests/integration/test_plugins.py
@@ -44,6 +44,7 @@ async def test_build_and_deploy(ops_test: OpsTest, kafka_connect_charm):
             resources={PLUGIN_RESOURCE_KEY: "./tests/integration/resources/FakeResource.tar"},
             num_units=1,
             series="jammy",
+            config={"profile": "testing"},
         ),
         ops_test.model.deploy(
             KAFKA_APP,

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -48,7 +48,12 @@ async def test_deploy_app_and_integrator(
 
     # deploy kafka & kafka connect
     await asyncio.gather(
-        ops_test.model.deploy(kafka_connect_charm, application_name=APP_NAME, series="jammy"),
+        ops_test.model.deploy(
+            kafka_connect_charm,
+            application_name=APP_NAME,
+            series="jammy",
+            config={"profile": "testing"},
+        ),
         ops_test.model.deploy(
             KAFKA_APP,
             channel=KAFKA_CHANNEL,

--- a/tests/integration/test_requirer.py
+++ b/tests/integration/test_requirer.py
@@ -36,7 +36,12 @@ logger = logging.getLogger(__name__)
 async def test_build_and_deploy(ops_test: OpsTest, kafka_connect_charm):
     """Deploys a basic test setup with Kafka, Kafka Connect, MySQL, and PostgreSQL."""
     await asyncio.gather(
-        ops_test.model.deploy(kafka_connect_charm, application_name=APP_NAME, series="jammy"),
+        ops_test.model.deploy(
+            kafka_connect_charm,
+            application_name=APP_NAME,
+            series="jammy",
+            config={"profile": "testing"},
+        ),
         ops_test.model.deploy(
             KAFKA_APP,
             channel=KAFKA_CHANNEL,

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -31,7 +31,12 @@ async def test_deploy_tls(ops_test: OpsTest, kafka_connect_charm):
         ops_test.model.deploy(
             TLS_APP, channel="stable", config=TLS_CONFIG, series="jammy", revision=155
         ),
-        ops_test.model.deploy(kafka_connect_charm, application_name=APP_NAME, series="jammy"),
+        ops_test.model.deploy(
+            kafka_connect_charm,
+            application_name=APP_NAME,
+            series="jammy",
+            config={"profile": "testing"},
+        ),
         ops_test.model.deploy(
             KAFKA_APP,
             channel=KAFKA_CHANNEL,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import yaml
+from ops.testing import Context, State
+from pydantic import ValidationError
+from src.charm import ConnectCharm
+from src.core.structured_config import CharmConfig
+from src.managers.config import DEFAULT_CONFIG_OPTIONS
+from typing_extensions import override
+
+logger = logging.getLogger(__name__)
+
+CONFIG = yaml.safe_load(Path("./config.yaml").read_text())
+
+
+@dataclass
+class ConfigOverride:
+    """Helper dataclass for overriding default charm config value(s) in parametrized tests."""
+
+    key: str
+    values: list[Any]
+    valid: bool = True
+
+    @override
+    def __str__(self):
+        state = "VALID" if self.valid else "INVALID"
+        return f'{self.key}: {",".join([str(v) for v in self.values])} -> {state}'
+
+
+def test_defaults(ctx: Context, base_state: State) -> None:
+    """Checks `ConfigManager` populates default config properties properly based on charm config & opinionated, hard-coded defaults."""
+    # Given
+    state_in = base_state
+
+    # When
+    with (ctx(ctx.on.update_status(), state_in) as mgr,):
+        charm: ConnectCharm = cast(ConnectCharm, mgr.charm)
+        _ = mgr.run()
+
+    # Then
+    for line in DEFAULT_CONFIG_OPTIONS.split("\n"):
+        assert line.strip() in charm.config_manager.properties
+
+    assert "exactly.once.source.support=disabled" in charm.config_manager.properties
+    assert (
+        "key.converter=org.apache.kafka.connect.json.JsonConverter"
+        in charm.config_manager.properties
+    )
+    assert (
+        "value.converter=org.apache.kafka.connect.json.JsonConverter"
+        in charm.config_manager.properties
+    )
+
+    # blacklists assertion
+    assert "profile=production" not in charm.config_manager.properties
+    assert "# profile=production" in charm.config_manager.properties
+    assert "rest_port=8083" not in charm.config_manager.properties
+    assert "# rest_port=8083" in charm.config_manager.properties
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        ConfigOverride(key="exactly_once_source_support", values=["enabled", "disabled"]),
+        ConfigOverride(
+            key="exactly_once_source_support", values=["abc", None, 123, True, "true"], valid=False
+        ),
+        ConfigOverride(key="profile", values=["testing", "production"]),
+        ConfigOverride(key="profile", values=["unknown", "test", None, 123, True], valid=False),
+    ],
+    ids=lambda override: f"{override}",
+)
+def test_validator(override: ConfigOverride) -> None:
+    """Tests `CharmConfig` validator functionality."""
+    defaults = {k: v["default"] for k, v in CONFIG["options"].items()}
+
+    for value in override.values:
+        target_config = defaults | {override.key: value}
+
+        if not override.valid:
+            with pytest.raises(ValidationError):
+                config = CharmConfig(**target_config)
+        else:
+            config = CharmConfig(**target_config)
+            assert getattr(config, override.key) == value

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -71,9 +71,11 @@ def test_defaults(ctx: Context, base_state: State) -> None:
 @pytest.mark.parametrize(
     "override",
     [
-        ConfigOverride(key="exactly_once_source_support", values=["enabled", "disabled"]),
+        ConfigOverride(key="exactly_once_source_support", values=[False, True]),
         ConfigOverride(
-            key="exactly_once_source_support", values=["abc", None, 123, True, "true"], valid=False
+            key="exactly_once_source_support",
+            values=["abc", None, 123, "enabled", "disabled"],
+            valid=False,
         ),
         ConfigOverride(key="log_level", values=["DEBUG", "ERROR", "INFO", "WARNING"]),
         ConfigOverride(

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -185,7 +185,7 @@ def test_tls_certificate_available(
 
     # Then
     assert state_out.unit_status == Status.MISSING_KAFKA.value.status
-    assert tls_manager_mock.configure.call_count == 1
+    tls_manager_mock.configure.assert_called_once()
     assert peer_rel.local_unit_data.get(TLSContext.CERT, "")
     assert peer_rel.local_unit_data.get(TLSContext.CA, "")
     assert peer_rel.local_unit_data.get(TLSContext.CHAIN, "")

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -185,12 +185,7 @@ def test_tls_certificate_available(
 
     # Then
     assert state_out.unit_status == Status.MISSING_KAFKA.value.status
-    assert tls_manager_mock.set_truststore.call_count == 1
-    assert tls_manager_mock.set_keystore.call_count == 1
-    assert tls_manager_mock.set_ca.call_count == 1
-    assert tls_manager_mock.set_certificate.call_count == 1
-    assert tls_manager_mock.set_chain.call_count == 1
-    assert tls_manager_mock.set_server_key.call_count == 1
+    assert tls_manager_mock.configure.call_count == 1
     assert peer_rel.local_unit_data.get(TLSContext.CERT, "")
     assert peer_rel.local_unit_data.get(TLSContext.CA, "")
     assert peer_rel.local_unit_data.get(TLSContext.CHAIN, "")


### PR DESCRIPTION
This PR adds opinionated config options to the charm. Moreover, some of the refactors related to the directory operations/upgrades on k8s are also ported here.

# Changes:
- Adds various user-managed, opinionated config options including `exactly_once_source_support`, `key_converter`, `value_converter`, `profile`, `log_level`.
- Adds various charm-managed, sensible configuration defaults.
- Ports dir. operations refactoring from k8s https://github.com/canonical/kafka-connect-operator/pull/20/commits/3ed5c4434f83fe2398066888e582b0d835a5c4f0
- Ports `charm.reconcile` method refactoring from k8s https://github.com/canonical/kafka-connect-operator/pull/20/commits/3ed5c4434f83fe2398066888e582b0d835a5c4f0