### PR TITLE
[DPE-6748] Extend integrator for multiple task handling

### DIFF
--- a/lib/charms/kafka_connect/v0/integrator.py
+++ b/lib/charms/kafka_connect/v0/integrator.py
@@ -461,6 +461,14 @@ class _DataInterfacesHelpers:
     def __init__(self, charm: CharmBase):
         self.charm = charm
 
+    def remote_app_name(self, relation_name: str) -> str:
+        """Returns the remote application name for the given relation name."""
+        relation = self.charm.model.get_relation(relation_name=relation_name)
+        if not relation:
+            return ""
+
+        return relation.app.name
+
     def fetch_all_relation_data(self, relation_name: str) -> MutableMapping:
         """Returns a MutableMapping of all relation data available to the unit on `relation_name`, either via databag or secrets."""
         relation = self.charm.model.get_relation(relation_name=relation_name)

--- a/lib/charms/kafka_connect/v0/integrator.py
+++ b/lib/charms/kafka_connect/v0/integrator.py
@@ -724,25 +724,6 @@ class BaseIntegrator(ABC, Object):
             logger.error(f"Unable to restart the connector, details: {e}")
             return
 
-    def stop_connector(self) -> None:
-        """Stops the connector."""
-        if self.connector_names:
-            for connector_name in self.connector_names:
-                    try:
-                        self._client.stop_connector(connector_name)
-                    except ConnectApiError as e:
-                        logger.error(f"Connector stop failed, details: {e}")
-                        return
-        else:
-            try:
-                self._client.stop_connector()
-            except ConnectApiError as e:
-                logger.error(f"Connector stop failed, details: {e}")
-                return
-
-        self.teardown()
-        self.started = False
-
     @property
     def task_status(self) -> TaskStatus:
         """Returns connector task status."""

--- a/lib/charms/kafka_connect/v0/integrator.py
+++ b/lib/charms/kafka_connect/v0/integrator.py
@@ -828,6 +828,5 @@ class BaseIntegrator(ABC, Object):
 
     def _on_relation_broken(self, _: RelationBrokenEvent) -> None:
         """Handler for `relation-broken` event."""
-        # TODO: remove from relation databag
         self.teardown()
         self.started = False

--- a/lib/charms/kafka_connect/v0/integrator.py
+++ b/lib/charms/kafka_connect/v0/integrator.py
@@ -367,6 +367,19 @@ class ConnectClient:
         if response.status_code != 204:
             raise ConnectApiError(f"Unable to stop the connector, details: {response.content}")
 
+    def delete_connector(self, connector_name: str | None = None) -> None:
+        """Deletes a connector at connectors/[CONNECTOR-NAME|connector-name] endpoint.
+
+        Raises:
+            ConnectApiError: If unsuccessful.
+        """
+        response = self.request(
+            method="DELETE", api=f"connectors/{connector_name or self.connector_name}"
+        )
+
+        if response.status_code != 204:
+            raise ConnectApiError(f"Unable to remove the connector, details: {response.content}")
+
     def patch_connector(
         self, connector_config: dict, connector_name: str | None = None
     ) -> None:
@@ -803,5 +816,6 @@ class BaseIntegrator(ABC, Object):
 
     def _on_relation_broken(self, _: RelationBrokenEvent) -> None:
         """Handler for `relation-broken` event."""
+        # TODO: remove from relation databag
         self.teardown()
         self.started = False

--- a/lib/charms/kafka_connect/v0/integrator.py
+++ b/lib/charms/kafka_connect/v0/integrator.py
@@ -57,9 +57,6 @@ class ConnectApiError(Exception):
 
 IntegratorMode = Literal["source", "sink"]
 
-# Used on MirrorMaker, the integrator needs to spawn 3 connectors per relation
-MULTICONNECTOR_PREFIX = "mirror"
-
 
 class TaskStatus(str, Enum):
     """Enum for Connector task status representation."""
@@ -346,7 +343,9 @@ class ConnectClient:
         Raises:
             ConnectApiError: If unsuccessful.
         """
-        response = self.request(method="PUT", api=f"connectors/{connector_name or self.connector_name}/resume")
+        response = self.request(
+            method="PUT", api=f"connectors/{connector_name or self.connector_name}/resume"
+        )
 
         if response.status_code == 202:
             return
@@ -380,9 +379,7 @@ class ConnectClient:
         if response.status_code != 204:
             raise ConnectApiError(f"Unable to remove the connector, details: {response.content}")
 
-    def patch_connector(
-        self, connector_config: dict, connector_name: str | None = None
-    ) -> None:
+    def patch_connector(self, connector_config: dict, connector_name: str | None = None) -> None:
         """Patches a connector by PATCHting `connector_config` to the `connectors/<CONNECTOR-NAME>` endpoint.
 
         Raises:
@@ -510,6 +507,8 @@ class BaseIntegrator(ABC, Object):
     CONFIG_SECRET_FIELD = "config"
     CONNECT_REL = "connect-client"
     PEER_REL = "peer"
+    # Used on MirrorMaker, the integrator needs to spawn 3 connectors per relation
+    MULTICONNECTOR_PREFIX = "mirror"
 
     def __init__(
         self,
@@ -638,7 +637,7 @@ class BaseIntegrator(ABC, Object):
         """Return a list of connector names that the integrator should create."""
         connectors = []
         for name in self.dynamic_config.keys():
-            if name.startswith(MULTICONNECTOR_PREFIX):
+            if name.startswith(self.MULTICONNECTOR_PREFIX):
                 connectors.append(name)
         return connectors
 
@@ -647,17 +646,17 @@ class BaseIntegrator(ABC, Object):
     def configure(self, config: dict[str, Any] | list[dict[str, Any]]) -> None:
         """Dynamically configure the connector with provided `config` dictionary.
 
-        Configuration provided using this method will override default config and config provided 
+        Configuration provided using this method will override default config and config provided
         by juju runtime (i.e. defined using the `BaseConfigFormmatter` interface).
         All configuration provided using this method are persisted using juju secrets.
-        Each call would update the previous provided configuration (if any), mimicking the 
+        Each call would update the previous provided configuration (if any), mimicking the
         `dict.update()` behavior.
 
         Args:
-            config (dict[str, Any] | list[dict[str, Any]]): 
+            config (dict[str, Any] | list[dict[str, Any]]):
                 - If a single dict is provided, updates the configuration for a single connector.
-                - If a list of dicts is provided, it will create multiple connector. Each dict in 
-                  the list represents a separate connector configuration. A "name" key should be 
+                - If a list of dicts is provided, it will create multiple connector. Each dict in
+                  the list represents a separate connector configuration. A "name" key should be
                   used to help differentiate connector names.
         """
         if self._peer_relation is None:
@@ -673,9 +672,11 @@ class BaseIntegrator(ABC, Object):
         if isinstance(config, list):
             for connector_config in config:
                 try:
-                    connector_id = f"{MULTICONNECTOR_PREFIX}_{connector_config['name']}_{self.connector_unique_name}"
+                    connector_id = f"{self.MULTICONNECTOR_PREFIX}_{connector_config['name']}_{self.connector_unique_name}"
                 except KeyError:
-                    logger.error("List of connectors should provide a 'name' key to differentiate them")
+                    logger.error(
+                        "List of connectors should provide a 'name' key to differentiate them"
+                    )
                     raise
 
                 # Remove "name" key so it's not part of the config passed to the JSON afterwards
@@ -683,8 +684,7 @@ class BaseIntegrator(ABC, Object):
                 updated_config[connector_id] = connector_config
 
         self._peer_unit_interface.update_relation_data(
-            self._peer_relation.id, 
-            data={self.CONFIG_SECRET_FIELD: json.dumps(updated_config)}
+            self._peer_relation.id, data={self.CONFIG_SECRET_FIELD: json.dumps(updated_config)}
         )
 
     def start_connector(self) -> None:
@@ -699,7 +699,10 @@ class BaseIntegrator(ABC, Object):
         for connector_name in self.connector_names:
             try:
                 self._client.start_connector(
-                    connector_config=self.formatter.to_dict(charm_config=self.config, mode="source") | self.dynamic_config[connector_name],
+                    connector_config=self.formatter.to_dict(
+                        charm_config=self.config, mode="source"
+                    )
+                    | self.dynamic_config[connector_name],
                     connector_name=connector_name,
                 )
             except ConnectApiError as e:
@@ -709,7 +712,10 @@ class BaseIntegrator(ABC, Object):
         # Single connector case
         if not self.connector_names:
             try:
-                self._client.start_connector(self.formatter.to_dict(charm_config=self.config, mode="source") | self.dynamic_config)
+                self._client.start_connector(
+                    self.formatter.to_dict(charm_config=self.config, mode="source")
+                    | self.dynamic_config
+                )
             except ConnectApiError as e:
                 logger.error(f"Connector start failed, details: {e}")
                 return
@@ -743,7 +749,10 @@ class BaseIntegrator(ABC, Object):
         for connector_name in self.connector_names:
             try:
                 self._client.patch_connector(
-                    connector_config=self.formatter.to_dict(charm_config=self.config, mode="source") | self.dynamic_config[connector_name],
+                    connector_config=self.formatter.to_dict(
+                        charm_config=self.config, mode="source"
+                    )
+                    | self.dynamic_config[connector_name],
                     connector_name=connector_name,
                 )
             except ConnectApiError as e:
@@ -753,7 +762,10 @@ class BaseIntegrator(ABC, Object):
         # Single connector case
         if not self.connector_names:
             try:
-                self._client.patch_connector(self.formatter.to_dict(charm_config=self.config, mode="source") | self.dynamic_config)
+                self._client.patch_connector(
+                    self.formatter.to_dict(charm_config=self.config, mode="source")
+                    | self.dynamic_config
+                )
             except ConnectApiError as e:
                 logger.error(f"Connector start failed, details: {e}")
                 return

--- a/lib/charms/kafka_connect/v0/integrator.py
+++ b/lib/charms/kafka_connect/v0/integrator.py
@@ -392,6 +392,9 @@ class ConnectClient:
         )
 
         if response.status_code == 200:
+            logger.debug(
+                f"Connector {connector_name or self.connector_name} patched: {connector_config}"
+            )
             return
 
         logger.error(response.content)

--- a/src/events/provider.py
+++ b/src/events/provider.py
@@ -112,7 +112,7 @@ class ConnectProvider(Object):
         self.charm.connect_manager.remove_plugin(path_prefix=username)
 
         if self.charm.unit.is_leader():
-            self.charm.connect_manager.stop_connector(event.relation.id)
+            self.charm.connect_manager.delete_connector(event.relation.id)
 
         if self.charm.connect_manager.connector_status(event.relation.id) == TaskStatus.RUNNING:
             event.defer()

--- a/src/managers/connect.py
+++ b/src/managers/connect.py
@@ -248,26 +248,19 @@ class ConnectManager:
 
         return TaskStatus.UNKNOWN
 
-    def stop_connector(self, relation_id: int) -> None:
-        """Stops the managed connector instance for given `relation_id`."""
-        for connector, status in self.connectors.items():
+    def delete_connector(self, relation_id: int) -> None:
+        """Deletes the managed connector instance for given `relation_id`."""
+        for connector, _ in self.connectors.items():
             if not re.match(self._managed_connector_regex(relation_id), connector):
                 continue
 
-            if status == TaskStatus.STOPPED:
-                logger.debug("Connector is already stopped.")
-                return
-
-            resp = self._request("PUT", f"connectors/{connector}/stop")
+            resp = self._request("DELETE", f"connectors/{connector}")
 
             if resp.status_code == 204:
-                logger.debug(f"Successfully stopped connector for relation ID={relation_id}.")
-                return
-
-            logger.error(f"Unable to stop connector, details: {resp.content}")
-            return
-
-        logger.error(f"Unable to find a managed connector for relation ID={relation_id}")
+                logger.debug(f"Successfully deleted connector for relation ID={relation_id}.")
+            else:
+                logger.error(f"Unable to delete connector, details: {resp.content}")
+                continue
 
     @retry(
         wait=wait_fixed(3),

--- a/tests/integration/sink-integrator-charm/lib/charms/kafka_connect/v0/integrator.py
+++ b/tests/integration/sink-integrator-charm/lib/charms/kafka_connect/v0/integrator.py
@@ -461,6 +461,14 @@ class _DataInterfacesHelpers:
     def __init__(self, charm: CharmBase):
         self.charm = charm
 
+    def remote_app_name(self, relation_name: str) -> str:
+        """Returns the remote application name for the given relation name."""
+        relation = self.charm.model.get_relation(relation_name=relation_name)
+        if not relation:
+            return ""
+
+        return relation.app.name
+
     def fetch_all_relation_data(self, relation_name: str) -> MutableMapping:
         """Returns a MutableMapping of all relation data available to the unit on `relation_name`, either via databag or secrets."""
         relation = self.charm.model.get_relation(relation_name=relation_name)
@@ -828,6 +836,5 @@ class BaseIntegrator(ABC, Object):
 
     def _on_relation_broken(self, _: RelationBrokenEvent) -> None:
         """Handler for `relation-broken` event."""
-        # TODO: remove from relation databag
         self.teardown()
         self.started = False

--- a/tests/integration/sink-integrator-charm/lib/charms/kafka_connect/v0/integrator.py
+++ b/tests/integration/sink-integrator-charm/lib/charms/kafka_connect/v0/integrator.py
@@ -166,7 +166,7 @@ class ConfigOption(BaseModel):
         description (str, optional): A brief description of this config option, which will be added to the charm's `config.yaml`.
     """
 
-    json_key: str  # Config key in the Task configuration JSON
+    json_key: str  # Config key in the Connector configuration JSON
     default: Any  # Default value
     mode: Literal[
         "both", "source", "sink", "none"
@@ -176,7 +176,7 @@ class ConfigOption(BaseModel):
 
 
 class BaseConfigFormatter:
-    """Object used for mapping charm config keys to connector task JSON configuration keys and/or setting default configuration values.
+    """Object used for mapping charm config keys to connector JSON configuration keys and/or setting default configuration values.
 
     Mapping of charm config keys to JSON config keys is provided via `ConfigOption` class variables.
 
@@ -210,7 +210,7 @@ class BaseConfigFormatter:
             option = cast(ConfigOption, getattr(cls, k))
 
             if option.mode == "none":
-                # This is not a task config option
+                # This is not a connector config option
                 continue
 
             if option.mode != "both" and option.mode != mode:
@@ -315,13 +315,16 @@ class ConnectClient:
 
         return response
 
-    def start_connector(self, task_config: dict) -> None:
-        """Starts a connector task by posting `task_config` to the `connectors` endpoint.
+    def start_connector(self, connector_config: dict, connector_name: str | None = None) -> None:
+        """Starts a connector by posting `connector_config` to the `connectors` endpoint.
 
         Raises:
             ConnectApiError: If unsuccessful.
         """
-        _json = {"name": self.connector_name, "config": task_config}
+        _json = {
+            "name": connector_name or self.connector_name,
+            "config": connector_config,
+        }
         response = self.request(method="POST", api="connectors", json=_json)
 
         if response.status_code == 201:
@@ -334,13 +337,15 @@ class ConnectClient:
         logger.error(response.content)
         raise ConnectApiError(f"Unable to start the connector, details: {response.content}")
 
-    def resume_connector(self) -> None:
+    def resume_connector(self, connector_name: str | None = None) -> None:
         """Resumes a connector task by PUTting to the `connectors/<CONNECTOR-NAME>/resume` endpoint.
 
         Raises:
             ConnectApiError: If unsuccessful.
         """
-        response = self.request(method="PUT", api=f"connectors/{self.connector_name}/resume")
+        response = self.request(
+            method="PUT", api=f"connectors/{connector_name or self.connector_name}/resume"
+        )
 
         if response.status_code == 202:
             return
@@ -348,22 +353,55 @@ class ConnectClient:
         logger.error(response.content)
         raise ConnectApiError(f"Unable to resume the connector, details: {response.content}")
 
-    def stop_connector(self) -> None:
-        """Stops a connector by making a request to connectors/CONNECTOR-NAME/stop endpoint.
+    def stop_connector(self, connector_name: str | None = None) -> None:
+        """Stops a connector at connectors/[CONNECTOR-NAME|connector-name]/stop endpoint.
 
         Raises:
             ConnectApiError: If unsuccessful.
         """
-        response = self.request(method="PUT", api=f"connectors/{self.connector_name}/stop")
+        response = self.request(
+            method="PUT", api=f"connectors/{connector_name or self.connector_name}/stop"
+        )
 
         if response.status_code != 204:
             raise ConnectApiError(f"Unable to stop the connector, details: {response.content}")
 
-    def task_status(self) -> TaskStatus:
-        """Returns the task(s) status of a connector."""
+    def delete_connector(self, connector_name: str | None = None) -> None:
+        """Deletes a connector at connectors/[CONNECTOR-NAME|connector-name] endpoint.
+
+        Raises:
+            ConnectApiError: If unsuccessful.
+        """
         response = self.request(
-            method="GET", api=f"connectors/{self.connector_name}/tasks", timeout=10
+            method="DELETE", api=f"connectors/{connector_name or self.connector_name}"
         )
+
+        if response.status_code != 204:
+            raise ConnectApiError(f"Unable to remove the connector, details: {response.content}")
+
+    def patch_connector(self, connector_config: dict, connector_name: str | None = None) -> None:
+        """Patches a connector by PATCHting `connector_config` to the `connectors/<CONNECTOR-NAME>` endpoint.
+
+        Raises:
+            ConnectApiError: If unsuccessful.
+        """
+        response = self.request(
+            method="PATCH",
+            api=f"connectors/{connector_name or self.connector_name}/config",
+            json=connector_config,
+        )
+
+        if response.status_code == 200:
+            return
+
+        logger.error(response.content)
+        raise ConnectApiError(f"Unable to patch the connector, details: {response.content}")
+
+    def task_status(self, connector_name: str | None = None) -> TaskStatus:
+        """Returns the task status of a connector."""
+        connector_name = connector_name or self.connector_name
+
+        response = self.request(method="GET", api=f"connectors/{connector_name}/tasks", timeout=10)
 
         if response.status_code not in (200, 404):
             logger.error(f"Unable to fetch tasks status, details: {response.content}")
@@ -380,7 +418,7 @@ class ConnectClient:
         task_id = tasks[0].get("id", {}).get("task", 0)
         status_response = self.request(
             method="GET",
-            api=f"connectors/{self.connector_name}/tasks/{task_id}/status",
+            api=f"connectors/{connector_name}/tasks/{task_id}/status",
             timeout=10,
         )
 
@@ -469,6 +507,8 @@ class BaseIntegrator(ABC, Object):
     CONFIG_SECRET_FIELD = "config"
     CONNECT_REL = "connect-client"
     PEER_REL = "peer"
+    # Used on MirrorMaker, the integrator needs to spawn 3 connectors per relation
+    MULTICONNECTOR_PREFIX = "mirror"
 
     def __init__(
         self,
@@ -491,6 +531,8 @@ class BaseIntegrator(ABC, Object):
         self.config = charm.config
         self.mode: IntegratorMode = cast(IntegratorMode, self.config.get("mode", self.mode))
         self.helpers: _DataInterfacesHelpers = _DataInterfacesHelpers(self.charm)
+
+        self._connector_names: list[str] = []
 
         # init handlers
         self.rel_name = self.CONNECT_REL
@@ -556,7 +598,7 @@ class BaseIntegrator(ABC, Object):
 
     @property
     def started(self) -> bool:
-        """Returns True if connector task is started, False otherwise."""
+        """Returns True if connector is started, False otherwise."""
         if self._peer_relation is None:
             return False
 
@@ -590,44 +632,99 @@ class BaseIntegrator(ABC, Object):
             )
         )
 
+    @property
+    def connector_names(self) -> list[str]:
+        """Return a list of connector names that the integrator should create."""
+        connectors = []
+        for name in self.dynamic_config.keys():
+            if name.startswith(self.MULTICONNECTOR_PREFIX):
+                connectors.append(name)
+        return connectors
+
     # Public methods
 
-    def configure(self, config: dict[str, Any]) -> None:
+    def configure(self, config: dict[str, Any] | list[dict[str, Any]]) -> None:
         """Dynamically configure the connector with provided `config` dictionary.
 
-        Configuration provided using this method will override default config and config provided by juju runtime (i.e. defined using the `BaseConfigFormmatter` interface).
+        Configuration provided using this method will override default config and config provided
+        by juju runtime (i.e. defined using the `BaseConfigFormmatter` interface).
         All configuration provided using this method are persisted using juju secrets.
-        Each call would update the previous provided configuration (if any), mimicking the `dict.update()` behavior.
+        Each call would update the previous provided configuration (if any), mimicking the
+        `dict.update()` behavior.
+
+        Args:
+            config (dict[str, Any] | list[dict[str, Any]]):
+                - If a single dict is provided, updates the configuration for a single connector.
+                - If a list of dicts is provided, it will create multiple connector. Each dict in
+                  the list represents a separate connector configuration. A "name" key should be
+                  used to help differentiate connector names.
         """
         if self._peer_relation is None:
             return
 
-        updated_config = self.dynamic_config | config
+        updated_config = self.dynamic_config.copy()
+
+        # Single configuration
+        if isinstance(config, dict):
+            updated_config.update(config)
+
+        # Multiple configurations
+        if isinstance(config, list):
+            for connector_config in config:
+                try:
+                    connector_id = f"{self.MULTICONNECTOR_PREFIX}_{connector_config['name']}_{self.connector_unique_name}"
+                except KeyError:
+                    logger.error(
+                        "List of connectors should provide a 'name' key to differentiate them"
+                    )
+                    raise
+
+                # Remove "name" key so it's not part of the config passed to the JSON afterwards
+                connector_config.pop("name")
+                updated_config[connector_id] = connector_config
 
         self._peer_unit_interface.update_relation_data(
             self._peer_relation.id, data={self.CONFIG_SECRET_FIELD: json.dumps(updated_config)}
         )
 
     def start_connector(self) -> None:
-        """Starts the connector."""
+        """Starts the connectors."""
         if self.started:
-            logger.info("Connector task has already started")
+            logger.info("Connector has already started")
             return
 
         self.setup()
 
-        try:
-            self._client.start_connector(
-                self.formatter.to_dict(self.config, self.mode) | self.dynamic_config
-            )
-        except ConnectApiError as e:
-            logger.error(f"Unable to start the connector, details: {e}")
-            return
+        # We have more than one connector to be executed. If list is empty, this is skipped
+        for connector_name in self.connector_names:
+            try:
+                self._client.start_connector(
+                    connector_config=self.formatter.to_dict(
+                        charm_config=self.config, mode="source"
+                    )
+                    | self.dynamic_config[connector_name],
+                    connector_name=connector_name,
+                )
+            except ConnectApiError as e:
+                logger.error(f"Connector start failed, details: {e}")
+                return
+
+        # Single connector case
+        if not self.connector_names:
+            try:
+                self._client.start_connector(
+                    self.formatter.to_dict(charm_config=self.config, mode="source")
+                    | self.dynamic_config
+                )
+            except ConnectApiError as e:
+                logger.error(f"Connector start failed, details: {e}")
+                return
 
         self.started = True
 
     def maybe_resume_connector(self) -> None:
         """Restarts/resumes the connector if it's in STOPPED state."""
+        # TODO: resume should cover multiple connectors existing
         if self.connector_status != TaskStatus.STOPPED:
             return
 
@@ -637,11 +734,53 @@ class BaseIntegrator(ABC, Object):
             logger.error(f"Unable to restart the connector, details: {e}")
             return
 
+    def patch_connector(self) -> None:
+        """Updates the connector(s) configuration.
+
+        Will override the existing configuration for the connector.
+        """
+        if not self.started:
+            logger.info("Connector is not started yet, skipping update.")
+            return
+
+        self.setup()
+
+        # We have more than one connector to be executed. If list is empty, this is skipped
+        for connector_name in self.connector_names:
+            try:
+                self._client.patch_connector(
+                    connector_config=self.formatter.to_dict(
+                        charm_config=self.config, mode="source"
+                    )
+                    | self.dynamic_config[connector_name],
+                    connector_name=connector_name,
+                )
+            except ConnectApiError as e:
+                logger.error(f"Connector start failed, details: {e}")
+                return
+
+        # Single connector case
+        if not self.connector_names:
+            try:
+                self._client.patch_connector(
+                    self.formatter.to_dict(charm_config=self.config, mode="source")
+                    | self.dynamic_config
+                )
+            except ConnectApiError as e:
+                logger.error(f"Connector start failed, details: {e}")
+                return
+
+        self.started = True
+
     @property
     def task_status(self) -> TaskStatus:
         """Returns connector task status."""
         if not self.started:
             return TaskStatus.UNASSIGNED
+
+        # TODO: status should be handled in a more complex way than this
+        if self.connector_names:
+            return self._client.task_status(connector_name=self.connector_names[0])
 
         return self._client.task_status()
 
@@ -655,17 +794,17 @@ class BaseIntegrator(ABC, Object):
     @property
     @abstractmethod
     def ready(self) -> bool:
-        """Should return True if all conditions for startig the task is met, including if all client relations are setup successfully."""
+        """Should return True if all conditions for startig the connector is met, including if all client relations are setup successfully."""
         ...
 
     @abstractmethod
     def setup(self) -> None:
-        """Should perform all necessary actions before connector task is started."""
+        """Should perform all necessary actions before connector is started."""
         ...
 
     @abstractmethod
     def teardown(self) -> None:
-        """Should perform all necessary cleanups after connector task is stopped."""
+        """Should perform all necessary cleanups after connector is stopped."""
         ...
 
     # Event handlers
@@ -677,7 +816,7 @@ class BaseIntegrator(ABC, Object):
             event.defer()
             return
 
-        logger.info(f"Starting {self.name} task...")
+        logger.info(f"Starting {self.name} connector...")
         self.start_connector()
 
         if not self.started:
@@ -689,5 +828,6 @@ class BaseIntegrator(ABC, Object):
 
     def _on_relation_broken(self, _: RelationBrokenEvent) -> None:
         """Handler for `relation-broken` event."""
+        # TODO: remove from relation databag
         self.teardown()
         self.started = False

--- a/tests/integration/sink-integrator-charm/lib/charms/kafka_connect/v0/integrator.py
+++ b/tests/integration/sink-integrator-charm/lib/charms/kafka_connect/v0/integrator.py
@@ -392,6 +392,9 @@ class ConnectClient:
         )
 
         if response.status_code == 200:
+            logger.debug(
+                f"Connector {connector_name or self.connector_name} patched: {connector_config}"
+            )
             return
 
         logger.error(response.content)

--- a/tests/integration/source-integrator-charm/lib/charms/kafka_connect/v0/integrator.py
+++ b/tests/integration/source-integrator-charm/lib/charms/kafka_connect/v0/integrator.py
@@ -461,6 +461,14 @@ class _DataInterfacesHelpers:
     def __init__(self, charm: CharmBase):
         self.charm = charm
 
+    def remote_app_name(self, relation_name: str) -> str:
+        """Returns the remote application name for the given relation name."""
+        relation = self.charm.model.get_relation(relation_name=relation_name)
+        if not relation:
+            return ""
+
+        return relation.app.name
+
     def fetch_all_relation_data(self, relation_name: str) -> MutableMapping:
         """Returns a MutableMapping of all relation data available to the unit on `relation_name`, either via databag or secrets."""
         relation = self.charm.model.get_relation(relation_name=relation_name)
@@ -828,6 +836,5 @@ class BaseIntegrator(ABC, Object):
 
     def _on_relation_broken(self, _: RelationBrokenEvent) -> None:
         """Handler for `relation-broken` event."""
-        # TODO: remove from relation databag
         self.teardown()
         self.started = False

--- a/tests/integration/source-integrator-charm/lib/charms/kafka_connect/v0/integrator.py
+++ b/tests/integration/source-integrator-charm/lib/charms/kafka_connect/v0/integrator.py
@@ -166,7 +166,7 @@ class ConfigOption(BaseModel):
         description (str, optional): A brief description of this config option, which will be added to the charm's `config.yaml`.
     """
 
-    json_key: str  # Config key in the Task configuration JSON
+    json_key: str  # Config key in the Connector configuration JSON
     default: Any  # Default value
     mode: Literal[
         "both", "source", "sink", "none"
@@ -176,7 +176,7 @@ class ConfigOption(BaseModel):
 
 
 class BaseConfigFormatter:
-    """Object used for mapping charm config keys to connector task JSON configuration keys and/or setting default configuration values.
+    """Object used for mapping charm config keys to connector JSON configuration keys and/or setting default configuration values.
 
     Mapping of charm config keys to JSON config keys is provided via `ConfigOption` class variables.
 
@@ -210,7 +210,7 @@ class BaseConfigFormatter:
             option = cast(ConfigOption, getattr(cls, k))
 
             if option.mode == "none":
-                # This is not a task config option
+                # This is not a connector config option
                 continue
 
             if option.mode != "both" and option.mode != mode:
@@ -315,13 +315,16 @@ class ConnectClient:
 
         return response
 
-    def start_connector(self, task_config: dict) -> None:
-        """Starts a connector task by posting `task_config` to the `connectors` endpoint.
+    def start_connector(self, connector_config: dict, connector_name: str | None = None) -> None:
+        """Starts a connector by posting `connector_config` to the `connectors` endpoint.
 
         Raises:
             ConnectApiError: If unsuccessful.
         """
-        _json = {"name": self.connector_name, "config": task_config}
+        _json = {
+            "name": connector_name or self.connector_name,
+            "config": connector_config,
+        }
         response = self.request(method="POST", api="connectors", json=_json)
 
         if response.status_code == 201:
@@ -334,13 +337,15 @@ class ConnectClient:
         logger.error(response.content)
         raise ConnectApiError(f"Unable to start the connector, details: {response.content}")
 
-    def resume_connector(self) -> None:
+    def resume_connector(self, connector_name: str | None = None) -> None:
         """Resumes a connector task by PUTting to the `connectors/<CONNECTOR-NAME>/resume` endpoint.
 
         Raises:
             ConnectApiError: If unsuccessful.
         """
-        response = self.request(method="PUT", api=f"connectors/{self.connector_name}/resume")
+        response = self.request(
+            method="PUT", api=f"connectors/{connector_name or self.connector_name}/resume"
+        )
 
         if response.status_code == 202:
             return
@@ -348,22 +353,55 @@ class ConnectClient:
         logger.error(response.content)
         raise ConnectApiError(f"Unable to resume the connector, details: {response.content}")
 
-    def stop_connector(self) -> None:
-        """Stops a connector by making a request to connectors/CONNECTOR-NAME/stop endpoint.
+    def stop_connector(self, connector_name: str | None = None) -> None:
+        """Stops a connector at connectors/[CONNECTOR-NAME|connector-name]/stop endpoint.
 
         Raises:
             ConnectApiError: If unsuccessful.
         """
-        response = self.request(method="PUT", api=f"connectors/{self.connector_name}/stop")
+        response = self.request(
+            method="PUT", api=f"connectors/{connector_name or self.connector_name}/stop"
+        )
 
         if response.status_code != 204:
             raise ConnectApiError(f"Unable to stop the connector, details: {response.content}")
 
-    def task_status(self) -> TaskStatus:
-        """Returns the task(s) status of a connector."""
+    def delete_connector(self, connector_name: str | None = None) -> None:
+        """Deletes a connector at connectors/[CONNECTOR-NAME|connector-name] endpoint.
+
+        Raises:
+            ConnectApiError: If unsuccessful.
+        """
         response = self.request(
-            method="GET", api=f"connectors/{self.connector_name}/tasks", timeout=10
+            method="DELETE", api=f"connectors/{connector_name or self.connector_name}"
         )
+
+        if response.status_code != 204:
+            raise ConnectApiError(f"Unable to remove the connector, details: {response.content}")
+
+    def patch_connector(self, connector_config: dict, connector_name: str | None = None) -> None:
+        """Patches a connector by PATCHting `connector_config` to the `connectors/<CONNECTOR-NAME>` endpoint.
+
+        Raises:
+            ConnectApiError: If unsuccessful.
+        """
+        response = self.request(
+            method="PATCH",
+            api=f"connectors/{connector_name or self.connector_name}/config",
+            json=connector_config,
+        )
+
+        if response.status_code == 200:
+            return
+
+        logger.error(response.content)
+        raise ConnectApiError(f"Unable to patch the connector, details: {response.content}")
+
+    def task_status(self, connector_name: str | None = None) -> TaskStatus:
+        """Returns the task status of a connector."""
+        connector_name = connector_name or self.connector_name
+
+        response = self.request(method="GET", api=f"connectors/{connector_name}/tasks", timeout=10)
 
         if response.status_code not in (200, 404):
             logger.error(f"Unable to fetch tasks status, details: {response.content}")
@@ -380,7 +418,7 @@ class ConnectClient:
         task_id = tasks[0].get("id", {}).get("task", 0)
         status_response = self.request(
             method="GET",
-            api=f"connectors/{self.connector_name}/tasks/{task_id}/status",
+            api=f"connectors/{connector_name}/tasks/{task_id}/status",
             timeout=10,
         )
 
@@ -469,6 +507,8 @@ class BaseIntegrator(ABC, Object):
     CONFIG_SECRET_FIELD = "config"
     CONNECT_REL = "connect-client"
     PEER_REL = "peer"
+    # Used on MirrorMaker, the integrator needs to spawn 3 connectors per relation
+    MULTICONNECTOR_PREFIX = "mirror"
 
     def __init__(
         self,
@@ -491,6 +531,8 @@ class BaseIntegrator(ABC, Object):
         self.config = charm.config
         self.mode: IntegratorMode = cast(IntegratorMode, self.config.get("mode", self.mode))
         self.helpers: _DataInterfacesHelpers = _DataInterfacesHelpers(self.charm)
+
+        self._connector_names: list[str] = []
 
         # init handlers
         self.rel_name = self.CONNECT_REL
@@ -556,7 +598,7 @@ class BaseIntegrator(ABC, Object):
 
     @property
     def started(self) -> bool:
-        """Returns True if connector task is started, False otherwise."""
+        """Returns True if connector is started, False otherwise."""
         if self._peer_relation is None:
             return False
 
@@ -590,44 +632,99 @@ class BaseIntegrator(ABC, Object):
             )
         )
 
+    @property
+    def connector_names(self) -> list[str]:
+        """Return a list of connector names that the integrator should create."""
+        connectors = []
+        for name in self.dynamic_config.keys():
+            if name.startswith(self.MULTICONNECTOR_PREFIX):
+                connectors.append(name)
+        return connectors
+
     # Public methods
 
-    def configure(self, config: dict[str, Any]) -> None:
+    def configure(self, config: dict[str, Any] | list[dict[str, Any]]) -> None:
         """Dynamically configure the connector with provided `config` dictionary.
 
-        Configuration provided using this method will override default config and config provided by juju runtime (i.e. defined using the `BaseConfigFormmatter` interface).
+        Configuration provided using this method will override default config and config provided
+        by juju runtime (i.e. defined using the `BaseConfigFormmatter` interface).
         All configuration provided using this method are persisted using juju secrets.
-        Each call would update the previous provided configuration (if any), mimicking the `dict.update()` behavior.
+        Each call would update the previous provided configuration (if any), mimicking the
+        `dict.update()` behavior.
+
+        Args:
+            config (dict[str, Any] | list[dict[str, Any]]):
+                - If a single dict is provided, updates the configuration for a single connector.
+                - If a list of dicts is provided, it will create multiple connector. Each dict in
+                  the list represents a separate connector configuration. A "name" key should be
+                  used to help differentiate connector names.
         """
         if self._peer_relation is None:
             return
 
-        updated_config = self.dynamic_config | config
+        updated_config = self.dynamic_config.copy()
+
+        # Single configuration
+        if isinstance(config, dict):
+            updated_config.update(config)
+
+        # Multiple configurations
+        if isinstance(config, list):
+            for connector_config in config:
+                try:
+                    connector_id = f"{self.MULTICONNECTOR_PREFIX}_{connector_config['name']}_{self.connector_unique_name}"
+                except KeyError:
+                    logger.error(
+                        "List of connectors should provide a 'name' key to differentiate them"
+                    )
+                    raise
+
+                # Remove "name" key so it's not part of the config passed to the JSON afterwards
+                connector_config.pop("name")
+                updated_config[connector_id] = connector_config
 
         self._peer_unit_interface.update_relation_data(
             self._peer_relation.id, data={self.CONFIG_SECRET_FIELD: json.dumps(updated_config)}
         )
 
     def start_connector(self) -> None:
-        """Starts the connector."""
+        """Starts the connectors."""
         if self.started:
-            logger.info("Connector task has already started")
+            logger.info("Connector has already started")
             return
 
         self.setup()
 
-        try:
-            self._client.start_connector(
-                self.formatter.to_dict(self.config, self.mode) | self.dynamic_config
-            )
-        except ConnectApiError as e:
-            logger.error(f"Unable to start the connector, details: {e}")
-            return
+        # We have more than one connector to be executed. If list is empty, this is skipped
+        for connector_name in self.connector_names:
+            try:
+                self._client.start_connector(
+                    connector_config=self.formatter.to_dict(
+                        charm_config=self.config, mode="source"
+                    )
+                    | self.dynamic_config[connector_name],
+                    connector_name=connector_name,
+                )
+            except ConnectApiError as e:
+                logger.error(f"Connector start failed, details: {e}")
+                return
+
+        # Single connector case
+        if not self.connector_names:
+            try:
+                self._client.start_connector(
+                    self.formatter.to_dict(charm_config=self.config, mode="source")
+                    | self.dynamic_config
+                )
+            except ConnectApiError as e:
+                logger.error(f"Connector start failed, details: {e}")
+                return
 
         self.started = True
 
     def maybe_resume_connector(self) -> None:
         """Restarts/resumes the connector if it's in STOPPED state."""
+        # TODO: resume should cover multiple connectors existing
         if self.connector_status != TaskStatus.STOPPED:
             return
 
@@ -637,11 +734,53 @@ class BaseIntegrator(ABC, Object):
             logger.error(f"Unable to restart the connector, details: {e}")
             return
 
+    def patch_connector(self) -> None:
+        """Updates the connector(s) configuration.
+
+        Will override the existing configuration for the connector.
+        """
+        if not self.started:
+            logger.info("Connector is not started yet, skipping update.")
+            return
+
+        self.setup()
+
+        # We have more than one connector to be executed. If list is empty, this is skipped
+        for connector_name in self.connector_names:
+            try:
+                self._client.patch_connector(
+                    connector_config=self.formatter.to_dict(
+                        charm_config=self.config, mode="source"
+                    )
+                    | self.dynamic_config[connector_name],
+                    connector_name=connector_name,
+                )
+            except ConnectApiError as e:
+                logger.error(f"Connector start failed, details: {e}")
+                return
+
+        # Single connector case
+        if not self.connector_names:
+            try:
+                self._client.patch_connector(
+                    self.formatter.to_dict(charm_config=self.config, mode="source")
+                    | self.dynamic_config
+                )
+            except ConnectApiError as e:
+                logger.error(f"Connector start failed, details: {e}")
+                return
+
+        self.started = True
+
     @property
     def task_status(self) -> TaskStatus:
         """Returns connector task status."""
         if not self.started:
             return TaskStatus.UNASSIGNED
+
+        # TODO: status should be handled in a more complex way than this
+        if self.connector_names:
+            return self._client.task_status(connector_name=self.connector_names[0])
 
         return self._client.task_status()
 
@@ -655,17 +794,17 @@ class BaseIntegrator(ABC, Object):
     @property
     @abstractmethod
     def ready(self) -> bool:
-        """Should return True if all conditions for startig the task is met, including if all client relations are setup successfully."""
+        """Should return True if all conditions for startig the connector is met, including if all client relations are setup successfully."""
         ...
 
     @abstractmethod
     def setup(self) -> None:
-        """Should perform all necessary actions before connector task is started."""
+        """Should perform all necessary actions before connector is started."""
         ...
 
     @abstractmethod
     def teardown(self) -> None:
-        """Should perform all necessary cleanups after connector task is stopped."""
+        """Should perform all necessary cleanups after connector is stopped."""
         ...
 
     # Event handlers
@@ -677,7 +816,7 @@ class BaseIntegrator(ABC, Object):
             event.defer()
             return
 
-        logger.info(f"Starting {self.name} task...")
+        logger.info(f"Starting {self.name} connector...")
         self.start_connector()
 
         if not self.started:
@@ -689,5 +828,6 @@ class BaseIntegrator(ABC, Object):
 
     def _on_relation_broken(self, _: RelationBrokenEvent) -> None:
         """Handler for `relation-broken` event."""
+        # TODO: remove from relation databag
         self.teardown()
         self.started = False

--- a/tests/integration/source-integrator-charm/lib/charms/kafka_connect/v0/integrator.py
+++ b/tests/integration/source-integrator-charm/lib/charms/kafka_connect/v0/integrator.py
@@ -392,6 +392,9 @@ class ConnectClient:
         )
 
         if response.status_code == 200:
+            logger.debug(
+                f"Connector {connector_name or self.connector_name} patched: {connector_config}"
+            )
             return
 
         logger.error(response.content)

--- a/tests/integration/test_requirer.py
+++ b/tests/integration/test_requirer.py
@@ -225,7 +225,7 @@ async def test_relation_broken(ops_test: OpsTest):
             apps=[APP_NAME, POSTGRES_INTEGRATOR], idle_period=60, timeout=600
         )
 
-    await assert_connector_statuses(ops_test, running=1, stopped=1)
+    await assert_connector_statuses(ops_test, running=1)
 
     # relate again with connect
     await ops_test.model.add_relation(APP_NAME, POSTGRES_INTEGRATOR)
@@ -237,4 +237,4 @@ async def test_relation_broken(ops_test: OpsTest):
 
     # new connector should show up in RUNNING state,
     # while previous connector should be in STOPPED state.
-    await assert_connector_statuses(ops_test, running=2, stopped=1)
+    await assert_connector_statuses(ops_test, running=2)

--- a/tests/unit/test_connect_manager.py
+++ b/tests/unit/test_connect_manager.py
@@ -198,7 +198,7 @@ def test_connector_lifecycle_management(
 
         assert connect_manager.connector_status(12).value == expected_status[12]
 
-        connect_manager.delete_connector(12) 
+        connect_manager.delete_connector(12)
         assert caplog.messages[-1] == "Successfully deleted connector for relation ID=12."
 
         response.status_code = 500

--- a/tests/unit/test_connect_manager.py
+++ b/tests/unit/test_connect_manager.py
@@ -176,7 +176,7 @@ def test_load_plugin_from_url(
 def test_connector_lifecycle_management(
     connect_manager: ConnectManager, healthy: bool, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Tests `connector_status` and `stop_connector` methods used for connector lifecycle management."""
+    """Tests `connector_status` and `delete_connector` methods used for connector lifecycle management."""
     with patch("requests.request") as _fake_request:
         connect_manager.health_check = lambda: healthy
         response = MagicMock()
@@ -194,16 +194,16 @@ def test_connector_lifecycle_management(
         response.status_code = 204
         for rel_id in (1, 11):
             assert connect_manager.connector_status(rel_id).value == expected_status[rel_id]
-            connect_manager.stop_connector(rel_id)
+            connect_manager.delete_connector(rel_id)
 
         assert connect_manager.connector_status(12).value == expected_status[12]
 
-        connect_manager.stop_connector(12)
-        assert caplog.messages[-1] == "Successfully stopped connector for relation ID=12."
+        connect_manager.delete_connector(12) 
+        assert caplog.messages[-1] == "Successfully deleted connector for relation ID=12."
 
         response.status_code = 500
-        connect_manager.stop_connector(12)
-        assert caplog.messages[-1].startswith("Unable to stop connector, details:")
+        connect_manager.delete_connector(12)
+        assert caplog.messages[-1].startswith("Unable to delete connector, details:")
 
 
 @pytest.mark.parametrize("status_code", (200, 500))


### PR DESCRIPTION
For the MirrorMaker implementation to work, the connect lib needs updating to allow multiple tasks to be created.