### PR TITLE
[DPE-6682] - feat: use /health API endpoint for status

### DIFF
--- a/src/events/upgrade.py
+++ b/src/events/upgrade.py
@@ -61,7 +61,7 @@ class ConnectUpgrade(DataUpgrade):
     @override
     def pre_upgrade_check(self) -> None:
         default_message = "Pre-upgrade check failed and cannot safely upgrade"
-        if not self.charm.connect_manager.health_check():
+        if not self.charm.connect_manager.health():
             raise ClusterNotReadyError(message=default_message, cause="Cluster is not healthy")
 
     @override

--- a/src/literals.py
+++ b/src/literals.py
@@ -77,6 +77,8 @@ class Status(Enum):
         WaitingStatus("Waiting for Kafka cluster credentials"), "DEBUG"
     )
     SERVICE_NOT_RUNNING = StatusLevel(BlockedStatus("Worker service is not running"), "WARNING")
+    SERVICE_STARTING = StatusLevel(WaitingStatus("Worker is still starting up"), "INFO")
+    SERVICE_UNHEALTHY = StatusLevel(BlockedStatus("Worker is unable to handle requests"), "ERROR")
 
     ACTIVE = StatusLevel(ActiveStatus(), "DEBUG")
 

--- a/src/managers/connect.py
+++ b/src/managers/connect.py
@@ -32,6 +32,21 @@ from literals import EMPTY_PLUGIN_CHECKSUM, GROUP, SUBSTRATE, USER
 logger = logging.getLogger(__name__)
 
 
+class HealthResponse:
+    """Wrapper object for Connect /health response."""
+
+    def __init__(
+        self, status_code: int, status: str | None = None, message: str | None = None, **_
+    ):
+        self.status_code = status_code
+        self.status = status
+        self.message = message
+
+    def __bool__(self) -> bool:
+        """Returns True if 200 status code. Otherwise False."""
+        return self.status_code == 200
+
+
 class PluginDownloadFailedError(Exception):
     """Exception raised when plugin download fails."""
 
@@ -73,7 +88,7 @@ class ConnectManager:
     @property
     def connectors(self) -> dict[str, TaskStatus]:
         """Returns a mapping of connector names to their status."""
-        if not self.health_check():
+        if not self.health:
             return {}
 
         resp = self._request("GET", "/connectors?expand=status").json()
@@ -236,9 +251,9 @@ class ConnectManager:
             f"{self.workload.paths.plugins.rstrip('/')}/{path_prefix}*", glob=True
         )
 
-    def ping_connect_api(self) -> requests.Response:
-        """Makes a GET request to the unit's Connect API Endpoint and returns the response."""
-        return self._request("GET", "/")
+    def _get_health(self) -> requests.Response:
+        """Makes a GET request to the unit's Connect API /health Endpoint and returns the response."""
+        return self._request("GET", "/health")
 
     def connector_status(self, relation_id: int) -> TaskStatus:
         """Returns the managed connector status for given `relation_id`."""
@@ -273,21 +288,18 @@ class ConnectManager:
         wait=wait_fixed(3),
         stop=stop_after_attempt(5),
         retry=retry_any(
-            retry_if_result(lambda result: result is False), retry_if_exception(lambda _: True)
+            retry_if_result(lambda result: not result), retry_if_exception(lambda _: True)
         ),
-        retry_error_callback=lambda _: False,
+        retry_error_callback=lambda _: HealthResponse(status_code=-1),
     )
-    def health_check(self) -> bool:
+    def health(self) -> HealthResponse:
         """Checks the health of connect service by pinging the Connect API."""
-        response = self.ping_connect_api()
+        response = self._get_health()
 
-        if response.status_code != 200:
-            return False
+        if response.status_code in (200, 500, 503):
+            return HealthResponse(status_code=response.status_code, **response.json())
 
-        if self.KAFKA_CLUSTER_ID not in response.json():
-            return False
-
-        return True
+        return HealthResponse(status_code=response.status_code)
 
     def restart_worker(self) -> None:
         """Attempts to restart the connect worker."""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -11,6 +11,7 @@ import yaml
 from ops.testing import Container, Context, Resource, State
 from src.charm import ConnectCharm
 from src.literals import CONTAINER, PLUGIN_RESOURCE_KEY, SNAP_NAME, SUBSTRATE
+from src.managers.connect import HealthResponse
 
 CONFIG = yaml.safe_load(Path("./config.yaml").read_text())
 ACTIONS = yaml.safe_load(Path("./actions.yaml").read_text())
@@ -84,14 +85,28 @@ def plugin_resource():
     return Resource(name=PLUGIN_RESOURCE_KEY, path="./tests/unit/resources/FakePlugin.tar")
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def active_service():
     mock_response = MagicMock()
     mock_response.json.return_value = {}
 
     with (
         patch(
-            "managers.connect.ConnectManager.health_check", return_value=True
+            "managers.connect.ConnectManager.health", return_value=HealthResponse(status_code=200)
+        ) as patched_service,
+        patch("managers.connect.ConnectManager._request", return_value=mock_response),
+    ):
+        yield patched_service
+
+
+@pytest.fixture(scope="function")
+def dead_service():
+    mock_response = MagicMock()
+    mock_response.json.return_value = {}
+
+    with (
+        patch(
+            "managers.connect.ConnectManager.health", return_value=HealthResponse(status_code=503)
         ) as patched_service,
         patch("managers.connect.ConnectManager._request", return_value=mock_response),
     ):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -35,7 +35,7 @@ class ConfigOverride:
         return f'{self.key}: {",".join([str(v) for v in self.values])} -> {state}'
 
 
-def test_defaults(ctx: Context, base_state: State) -> None:
+def test_defaults(ctx: Context, base_state: State, active_service) -> None:
     """Checks `ConfigManager` populates default config properties properly based on charm config & opinionated, hard-coded defaults."""
     # Given
     state_in = base_state

--- a/tests/unit/test_connect_manager.py
+++ b/tests/unit/test_connect_manager.py
@@ -172,22 +172,16 @@ def test_load_plugin_from_url(
         assert "Plugin already exists." in caplog.messages
 
 
-@pytest.mark.parametrize("healthy", [True, False])
 def test_connector_lifecycle_management(
-    connect_manager: ConnectManager, healthy: bool, caplog: pytest.LogCaptureFixture
+    connect_manager: ConnectManager, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Tests `connector_status` and `stop_connector` methods used for connector lifecycle management."""
-    with patch("requests.request") as _fake_request:
-        connect_manager.health_check = lambda: healthy
+    with (patch("requests.request") as _fake_request,):
         response = MagicMock()
         response.json.return_value = STATUS_RESPONSE
         _fake_request.return_value = response
 
-        if not healthy:
-            assert not connect_manager.connectors
-            return
-        else:
-            assert len(connect_manager.connectors) == 3
+        assert len(connect_manager.connectors) == 3
 
         expected_status = {1: "UNKNOWN", 11: "STOPPED", 12: "RUNNING"}
 
@@ -206,20 +200,15 @@ def test_connector_lifecycle_management(
         assert caplog.messages[-1].startswith("Unable to stop connector, details:")
 
 
-@pytest.mark.parametrize("status_code", (200, 500))
-@pytest.mark.parametrize("bad_response", [True, False])
+@pytest.mark.parametrize("status_code,correct_response", [(200, True), (500, False), (404, False)])
 def test_health_check(
-    connect_manager: ConnectManager, status_code: int, bad_response: bool
+    connect_manager: ConnectManager, status_code: int, correct_response: bool
 ) -> None:
     """Tests ConnectManager health checking functionality."""
     with patch("requests.request") as _fake_request:
         response = MagicMock()
         response.status_code = status_code
-        response.json.return_value = (
-            {}
-            if status_code != 200 or bad_response
-            else {"kafka_cluster_id": "unique-id", "version": "3.9.0-ubuntu1"}
-        )
+        response.json.return_value = {}
         _fake_request.return_value = response
 
-        assert connect_manager.health_check() == (status_code == 200 and not bad_response)
+        assert bool(connect_manager.health()) is correct_response

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -42,7 +42,9 @@ def upgrade_func() -> str:
     return "_on_upgrade_granted"
 
 
-def test_pre_upgrade_check_raises_not_healthy(ctx: Context, base_state: State) -> None:
+def test_pre_upgrade_check_raises_not_healthy(
+    ctx: Context, base_state: State, dead_service
+) -> None:
     # Given
     state_in = base_state
 
@@ -54,13 +56,12 @@ def test_pre_upgrade_check_raises_not_healthy(ctx: Context, base_state: State) -
             charm.upgrade.pre_upgrade_check()
 
 
-def test_pre_upgrade_check_succeeds(ctx: Context, base_state: State) -> None:
+def test_pre_upgrade_check_succeeds(ctx: Context, base_state: State, active_service) -> None:
     # Given
     state_in = base_state
 
     # When
     with (
-        patch("managers.connect.ConnectManager.health_check", return_value=True),
         patch("events.upgrade.ConnectUpgrade._set_rolling_update_partition"),
         ctx(ctx.on.config_changed(), state_in) as manager,
     ):
@@ -122,7 +123,7 @@ def test_upgrade_granted_sets_failed_if_failed_snap(ctx: Context, base_state: St
 
 
 def test_upgrade_sets_failed_if_failed_upgrade_check(
-    ctx: Context, base_state: State, upgrade_func: str
+    ctx: Context, base_state: State, upgrade_func: str, dead_service
 ) -> None:
     # Given
     state_in = base_state
@@ -133,7 +134,6 @@ def test_upgrade_sets_failed_if_failed_upgrade_check(
         patch("workload.Workload.start") as patched_start,
         patch("workload.Workload.stop"),
         patch("workload.Workload.install"),
-        patch("managers.connect.ConnectManager.health_check", return_value=False),
         patch("core.models.Context.ready", return_value=True),
         patch(
             "events.upgrade.ConnectUpgrade.set_unit_failed",


### PR DESCRIPTION
## Changes Made
#### `feat: use /health API endpoint for status`
- 200 - healthy, 503 - starting up and 500 - unhealthy
- Exposed via new `HealthResponse` object, in case we want to do different behavior on particular health statuses once the service is up and running
    - For example, only retrying when `503` (starting up)
- Truthy if `200`, otherwise Falsey