### PR TITLE
chore: update rust version

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -75,7 +75,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.87.0  # renovate: charmcraft-rust-latest
 
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging

--- a/tests/integration/sink-integrator-charm/charmcraft.yaml
+++ b/tests/integration/sink-integrator-charm/charmcraft.yaml
@@ -15,7 +15,7 @@ parts:
       snap install rustup --classic
       rustup --version
       rustup set profile minimal
-      rustup default 1.83.0
+      rustup default 1.87.0
       craftctl default
     plugin: charm
 

--- a/tests/integration/source-integrator-charm/charmcraft.yaml
+++ b/tests/integration/source-integrator-charm/charmcraft.yaml
@@ -15,7 +15,7 @@ parts:
       snap install rustup --classic
       rustup --version
       rustup set profile minimal
-      rustup default 1.83.0
+      rustup default 1.87.0
       craftctl default
     plugin: charm
 


### PR DESCRIPTION
This PR updates rust to `1.87` in order to fix the scheduled tests failures due to outdated rust version:

https://github.com/canonical/kafka-connect-operator/actions/runs/15090916863/job/42419330374