### PR TITLE
[DPE-9107] feat: add machines support to TF module

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,7 @@ jobs:
           - integration-requirer
           - integration-scaling
           - integration-secrets
+          - integration-terraform
 
     name: ${{ matrix.tox-environments }}
     needs:
@@ -91,6 +92,10 @@ jobs:
         with:
           pattern: ${{ needs.build.outputs.artifact-prefix }}-*
           merge-multiple: true
+      - name: Setup terraform if needed
+        if: ${{ matrix.tox-environments == 'integration-terraform' }}
+        run: |
+          sudo snap install --classic terraform
       - name: Select tests
         id: select-tests
         run: |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,7 +9,8 @@ resource "juju_application" "connect" {
     base     = var.base
   }
 
-  units       = var.units
+  units       = length(var.machines) == 0 ? var.units : null
+  machines    = length(var.machines) > 0 ? var.machines : null
   constraints = var.constraints
   config      = var.config
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -45,3 +45,9 @@ variable "base" {
   type        = string
   default     = "ubuntu@22.04"
 }
+
+variable "machines" {
+  description = "List of juju_machine resources to use for deployment"
+  type        = set(string)
+  default     = []
+}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -90,6 +90,6 @@ async def model_uuid(ops_test: OpsTest) -> str:
         iter(
             mdl["model-uuid"]
             for mdl in json.loads(models_raw)["models"]
-            if mdl["short-name"] == ops_test.model_full_name
+            if mdl["short-name"] == ops_test.model.name
         )
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 
 
+import json
 import random
 import string
 from typing import cast
@@ -79,3 +80,16 @@ async def mysql_test_data(ops_test: OpsTest, request: pytest.FixtureRequest):
         await exec_query(
             f"INSERT INTO {params.db_name}.table_{i} (name, price) Values {', '.join(values)}"
         )
+
+
+@pytest.fixture(scope="module")
+async def model_uuid(ops_test: OpsTest) -> str:
+    ret, models_raw, _ = await ops_test.juju("models", "--format", "json")
+    assert not ret
+    return next(
+        iter(
+            mdl["model-uuid"]
+            for mdl in json.loads(models_raw)["models"]
+            if mdl["short-name"] == ops_test.model_full_name
+        )
+    )

--- a/tests/integration/test_terraform.py
+++ b/tests/integration/test_terraform.py
@@ -115,7 +115,6 @@ async def test_deployment_on_machines(ops_test: OpsTest, model_uuid: str, tmp_pa
     _destroy_terraform(working_dir)
 
     await ops_test.model.block_until(
-        lambda: len(ops_test.model.units) == 0
-        and len(ops_test.model.applications) == 0,
+        lambda: len(ops_test.model.units) == 0 and len(ops_test.model.applications) == 0,
         timeout=900,
     )

--- a/tests/integration/test_terraform.py
+++ b/tests/integration/test_terraform.py
@@ -116,7 +116,6 @@ async def test_deployment_on_machines(ops_test: OpsTest, model_uuid: str, tmp_pa
 
     await ops_test.model.block_until(
         lambda: len(ops_test.model.units) == 0
-        and len(ops_test.model.machines) == 0
         and len(ops_test.model.applications) == 0,
         timeout=900,
     )

--- a/tests/integration/test_terraform.py
+++ b/tests/integration/test_terraform.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Simple Terraform smoke tests."""
+
+import json
+import logging
+import os
+import random
+
+import pytest
+from helpers import APP_NAME
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+
+TFVARS_DEFAULTS = {
+    "app_name": APP_NAME,
+    "units": 3,
+}
+TFVARS_FILENAME = "test.tfvars.json"
+
+
+def _deploy_terraform(tmp_path, tfvars: dict = {}) -> str:
+    """Deploy the charm Terraform module, using a provided set of variables."""
+    tf_path = tmp_path / "terraform"
+    tf_path.mkdir()
+    logger.info(f"Using {tf_path}")
+    os.system(f"cp -R terraform/* {tf_path}/")
+
+    _tfvars = TFVARS_DEFAULTS | tfvars
+    with open(f"{tf_path}/{TFVARS_FILENAME}", "w") as f:
+        json.dump(_tfvars, f, indent=4)
+
+    ret_code = os.system(f"terraform -chdir={tf_path} init")
+    assert not ret_code
+    ret_code = os.system(
+        f"terraform -chdir={tf_path} apply -var-file={tf_path}/{TFVARS_FILENAME} -auto-approve"
+    )
+    assert not ret_code
+
+    return tf_path
+
+
+def _destroy_terraform(working_dir: str) -> None:
+    """Destroy the Terraform module and related tmp resources."""
+    ret_code = os.system(
+        f"terraform -chdir={working_dir} destroy -var-file={working_dir}/{TFVARS_FILENAME} -auto-approve"
+    )
+    assert not ret_code
+
+    os.system(f"rm -rf {working_dir}")
+
+
+@pytest.mark.abort_on_fail
+async def test_deployment_active(ops_test: OpsTest, model_uuid: str, tmp_path):
+    """Test that application is deployed and active."""
+    working_dir = _deploy_terraform(tmp_path, tfvars={"model_uuid": model_uuid})
+
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME], idle_period=60, timeout=900, status="active"
+    )
+
+    _destroy_terraform(working_dir)
+
+    await ops_test.model.block_until(
+        lambda: len(ops_test.model.units) == 0
+        and len(ops_test.model.machines) == 0
+        and len(ops_test.model.applications) == 0,
+        timeout=900,
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_deployment_on_machines(ops_test: OpsTest, model_uuid: str, tmp_path):
+    """Test that `machines` TF variable work as expected."""
+    # Add machines and wait for them to start
+    for _ in range(3):
+        await ops_test.model.add_machine(series="jammy")
+
+    await ops_test.model.block_until(
+        lambda: len(ops_test.model.machines) == 3
+        and {machine.status for machine in ops_test.model.machines} == {"started"},
+        timeout=900,
+    )
+
+    machines = list(ops_test.model.machines)
+    target_machine = random.choice(machines)
+
+    # Deploy 1 Kafka unit on a target machine
+    working_dir = _deploy_terraform(
+        tmp_path, tfvars={"model_uuid": model_uuid, "machines": [target_machine]}
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME], idle_period=60, timeout=900, status="active"
+    )
+
+    status = ops_test.model.applications
+    assert len(status[APP_NAME].units) == 1
+    deployed_unit = next(iter(status.apps[APP_NAME].units.values()))
+    assert deployed_unit.machine == target_machine
+
+    _destroy_terraform(working_dir)
+
+    await ops_test.model.block_until(
+        lambda: len(ops_test.model.units) == 0
+        and len(ops_test.model.machines) == 0
+        and len(ops_test.model.applications) == 0,
+        timeout=900,
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ set_env =
     requirer: TEST_FILE=test_requirer.py
     scaling: TEST_FILE=test_scaling.py
     secrets: TEST_FILE=test_user_secrets.py
+    terraform: TEST_FILE=test_terraform.py
 
 pass_env =
     PYTHONPATH
@@ -85,7 +86,7 @@ commands =
     poetry install --with integration
     poetry run pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/
 
-[testenv:integration-{charm,plugins,provider,requirer,scaling,secrets,tls,upgrade}]
+[testenv:integration-{charm,plugins,provider,requirer,scaling,secrets,terraform,tls,upgrade}]
 description = Run integration tests
 set_env =
     {[testenv]set_env}


### PR DESCRIPTION
Adds `machines` support and TF smoke tests, similar to https://github.com/canonical/kafka-operator/pull/463