### PR TITLE
ci: unpin juju agent & use SH runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
       - lint
       - unit-test
       - build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, AMD64, X64, large, noble]
     timeout-minutes: 240
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,7 +85,6 @@ jobs:
         with:
           provider: lxd
           juju-channel: 3.6/stable
-          bootstrap-options: "--agent-version 3.6.1"
       - name: Download packed charm(s)
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,11 +44,10 @@ jobs:
 
   build:
     name: Build charms
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v29.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v48
     with:
-      charmcraft-snap-channel: latest/candidate  # TODO: remove after charmcraft 3.3 stable release
+      charmcraft-snap-channel: latest/stable
       path-to-charm-directory: ${{ matrix.path }}
-      cache: false  # TODO: fix after being added to ccc
     strategy:
       matrix:
         path:


### PR DESCRIPTION
## Description

This PR removes the juju agent version pin in CI bootstrap phase, as it's broken with latest `3.6/stable` release of Juju. Also, switches to SH runners.