### PR TITLE
[DPE-10531] fix: TLS setup failure if chain is missing

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -162,7 +162,7 @@ class ConnectCharm(TypedCharmBase[CharmConfig]):
         self.connect.update_clients_data()
 
         # Check if SANs have changed.
-        if self.context.peer_workers.tls_enabled and self.tls_manager.sans_change_detected:
+        if self.context.tls_enabled and self.tls_manager.sans_change_detected:
             unit_tls_context = self.context.worker_unit.tls
             self.tls.certificates.on.certificate_expiring.emit(
                 certificate=unit_tls_context.certificate,

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -279,7 +279,7 @@ class TLSContext(RelationContext):
     @property
     def bundle(self) -> list[str]:
         """The cert bundle used for TLS identity."""
-        if not all([self.certificate, self.ca, self.chain]):
+        if not all([self.certificate, self.ca]):
             return []
 
         # manual-tls-certificates is loaded with the signed cert, the intermediate CA that signed it
@@ -302,7 +302,7 @@ class TLSContext(RelationContext):
     @property
     @override
     def status(self) -> Status:
-        return Status.ACTIVE
+        return Status.ACTIVE if all([self.private_key, self.bundle]) else Status.NO_CERT
 
 
 class WorkerUnitContext(RelationContext):
@@ -535,10 +535,18 @@ class Context(WithStatus, Object):
         return cache
 
     @property
+    def tls_enabled(self) -> bool:
+        """Returns True if TLS is enabled and active."""
+        return self.peer_workers.tls_enabled and self.worker_unit.tls.ready
+
+    @property
     @override
     def status(self) -> Status:
         if not self.kafka_client.ready:
             return self.kafka_client.status
+
+        if self.peer_workers.tls_enabled:
+            return self.worker_unit.tls.status
 
         return Status.ACTIVE
 

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -147,6 +147,7 @@ class WorkloadBase(ABC):
         env: dict[str, str] | None = None,
         working_dir: str | None = None,
         sensitive: bool = False,
+        log_on_error: bool = True,
     ) -> str:
         """Runs a command on the workload substrate."""
         ...

--- a/src/events/connect.py
+++ b/src/events/connect.py
@@ -119,9 +119,9 @@ class ConnectHandler(Object):
                     "endpoints": self.context.rest_endpoints,
                     "username": client.username,
                     "password": client.password,
-                    "tls": "enabled" if self.context.peer_workers.tls_enabled else "disabled",
+                    "tls": "enabled" if self.context.tls_enabled else "disabled",
                     "tls-ca": self.context.worker_unit.tls.ca
-                    if self.context.peer_workers.tls_enabled
+                    if self.context.tls_enabled
                     else "disabled",
                 }
             )

--- a/src/literals.py
+++ b/src/literals.py
@@ -78,6 +78,7 @@ class Status(Enum):
     SERVICE_NOT_RUNNING = StatusLevel(BlockedStatus("Worker service is not running"), "WARNING")
     SERVICE_STARTING = StatusLevel(WaitingStatus("Worker is still starting up"), "INFO")
     SERVICE_UNHEALTHY = StatusLevel(BlockedStatus("Worker is unable to handle requests"), "ERROR")
+    NO_CERT = StatusLevel(WaitingStatus("unit waiting for signed certificates"), "INFO")
 
     ACTIVE = StatusLevel(ActiveStatus(), "DEBUG")
 

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -216,7 +216,7 @@ class ConfigManager:
     @property
     def rest_tls_properties(self) -> list[str]:
         """Returns TLS properties for the REST API endpoint."""
-        if not self.context.peer_workers.tls_enabled:
+        if not self.context.tls_enabled:
             return []
 
         return [

--- a/src/managers/connect.py
+++ b/src/managers/connect.py
@@ -8,11 +8,13 @@ import logging
 import os
 import re
 import tempfile
+import warnings
 from pathlib import Path
 from subprocess import CalledProcessError
 from typing import Pattern
 
 import requests
+import urllib3
 from kafkacl.models import TaskStatus
 from requests.auth import HTTPBasicAuth
 from tenacity import (
@@ -118,12 +120,15 @@ class ConnectManager:
 
         url = f"{self.context.rest_uri}/{api}"
 
-        try:
-            response = requests.request(
-                method, url, verify=False, auth=auth, timeout=self.REQUEST_TIMEOUT, **kwargs
-            )
-        except Exception as e:
-            raise Exception(f"Connect API call /{api} failed: {e}")
+        with warnings.catch_warnings():
+            # FIXME: Connect Manager should use the CA chain to verify its requests.
+            warnings.simplefilter("ignore", urllib3.exceptions.InsecureRequestWarning)
+            try:
+                response = requests.request(
+                    method, url, verify=False, auth=auth, timeout=self.REQUEST_TIMEOUT, **kwargs
+                )
+            except Exception as e:
+                raise Exception(f"Connect API call /{api} failed: {e}")
 
         if verbose:
             logging.debug(f"{method} - {url}: {response.content}")

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -110,11 +110,11 @@ class TLSManager:
 
     def set_chain(self) -> None:
         """Sets the unit chain."""
-        if not self.tls_context.chain:
+        if not self.tls_context.bundle:
             logger.error("Can't set chain to unit, missing chain in relation data")
             return
 
-        for i, chain_cert in enumerate(self.tls_context.chain):
+        for i, chain_cert in enumerate(self.tls_context.bundle):
             self.workload.write(
                 content=chain_cert, path=f"{self.workload.paths.config_dir}/bundle{i}.pem"
             )
@@ -150,7 +150,11 @@ class TLSManager:
 
         command = f"{self.keytool} -import -v -alias {alias} -file {filename} -keystore {self.workload.paths.truststore} -storepass {self.tls_context.truststore_password} -noprompt"
         try:
-            self.workload.exec(command=command.split(), working_dir=self.workload.paths.config_dir)
+            self.workload.exec(
+                command=command.split(),
+                working_dir=self.workload.paths.config_dir,
+                log_on_error=False,
+            )
         except (subprocess.CalledProcessError, ExecError) as e:
             # in case this reruns and fails
             if e.stdout and "already exists" in e.stdout:

--- a/src/workload.py
+++ b/src/workload.py
@@ -87,6 +87,7 @@ class Workload(WorkloadBase):
         env: Mapping[str, str] | None = None,
         working_dir: str | None = None,
         sensitive: bool = True,
+        log_on_error: bool = True,
     ) -> str:
         should_log = not sensitive or self.log_sensitive_output
         try:
@@ -102,7 +103,7 @@ class Workload(WorkloadBase):
                 logger.debug(f"{output=}")
             return output
         except subprocess.CalledProcessError as e:
-            if should_log:
+            if should_log and log_on_error:
                 logger.error(f"cmd failed - cmd={e.cmd}, stdout={e.stdout}, stderr={e.stderr}")
             raise e
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -11,7 +11,7 @@ import tempfile
 from contextlib import closing, contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from subprocess import PIPE, check_output
+from subprocess import PIPE, CalledProcessError, check_output
 from typing import cast
 
 import requests
@@ -368,3 +368,86 @@ def destroy_active_workers(juju: JujuFixture):
         if get_unit_ipv4_address(juju, unit) in workers:
             logger.info(f"Destroying {unit}")
             juju.ext.model.applications[APP_NAME].destroy_units(unit.name)
+
+
+def sign_manual_certs(
+    tmp_path: Path, model: str, manual_app: str = "manual-tls-certificates"
+) -> str:
+    """Sign CSRs using a generated CA, return the path to the CA file."""
+    csrs_cmd = [
+        f"JUJU_MODEL={model}",
+        "juju",
+        "run",
+        f"{manual_app}/0",
+        "get-outstanding-certificate-requests",
+        "--format=json",
+    ]
+    csrs = check_output(" ".join(csrs_cmd), stderr=PIPE, universal_newlines=True, shell=True)
+    res = json.loads(csrs)[f"{manual_app}/0"]["results"]["result"]
+    csr_list = [i["csr"] for i in json.loads(res)]
+
+    # Generate a CA
+    generate_ca_cmd = [
+        "openssl",
+        "req",
+        "-new",
+        "-x509",
+        "-nodes",
+        "-newkey rsa:2048",
+        "-keyout ca.key",
+        "-out ca.pem",
+        "-days 365",
+        '-subj "/CN=TestCA"',
+        '-addext "basicConstraints=critical,CA:TRUE"',
+        '-addext "keyUsage=critical,keyCertSign,cRLSign"',
+        '-addext "subjectKeyIdentifier=hash"',
+    ]
+    check_output(
+        " ".join(generate_ca_cmd), stderr=PIPE, universal_newlines=True, shell=True, cwd=tmp_path
+    )
+
+    for i, csr in enumerate(csr_list):
+        if not csr:
+            continue
+
+        tmp_dir = Path(tmp_path)
+        csr_file = tmp_dir / f"csr{i}"
+        csr_file.write_text(csr)
+
+        cert_file = tmp_dir / f"{i}.pem"
+
+        try:
+            sign_cmd = [
+                "openssl",
+                "x509",
+                "-req",
+                f"-in {csr_file}",
+                f"-CAkey {tmp_path}/ca.key",
+                f"-CA {tmp_path}/ca.pem",
+                "-days 100",
+                "-CAcreateserial",
+                f"-out {cert_file}",
+                "-copy_extensions",
+                "copyall",
+            ]
+            provide_cmd = [
+                f"JUJU_MODEL={model}",
+                "juju",
+                "run",
+                f"{manual_app}/0",
+                "provide-certificate",
+                f'ca-certificate="$(base64 -w0 {tmp_path}/ca.pem)"',
+                f'certificate="$(base64 -w0 {cert_file})"',
+                f'certificate-signing-request="$(base64 -w0 {csr_file})"',
+            ]
+
+            check_output(" ".join(sign_cmd), stderr=PIPE, universal_newlines=True, shell=True)
+            response = check_output(
+                " ".join(provide_cmd), stderr=PIPE, universal_newlines=True, shell=True
+            )
+            logger.info(f"{response=}")
+        except CalledProcessError as e:
+            logger.error(f"{e.stdout=}, {e.stderr=}, {e.output=}")
+            raise e
+
+    return f"{tmp_path}/ca.pem"

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -10,6 +10,7 @@ from helpers import (
     make_connect_api_request,
     run_command_on_unit,
     self_signed_ca,
+    sign_manual_certs,
 )
 from jubilant_adapters import JujuFixture, gather
 from requests.exceptions import ConnectionError, SSLError
@@ -21,6 +22,8 @@ logger = logging.getLogger(__name__)
 TLS_APP = "self-signed-certificates"
 TLS_CHANNEL = "1/stable"
 TLS_CONFIG = {"ca-common-name": "kafka"}
+MANUAL_TLS_NAME = "manual-tls-certificates"
+MANUAL_TLS_CHANNEL = "1/stable"
 
 
 def test_deploy_tls(juju: JujuFixture, kafka_version: int, kafka_connect_charm):
@@ -104,3 +107,31 @@ def test_tls_broken(juju: JujuFixture):
         file_extensions = {f.split(".")[-1] for f in res.stdout.split() if f}
 
         assert not {"pem", "key", "p12", "jks"} & file_extensions
+
+
+def test_manual_tls_with_no_chain(juju: JujuFixture, tmp_path):
+    juju.ext.model.deploy(MANUAL_TLS_NAME, channel=MANUAL_TLS_CHANNEL)
+
+    juju.ext.model.add_relation(APP_NAME, MANUAL_TLS_NAME)
+
+    with juju.ext.fast_forward(fast_interval="60s"):
+        juju.ext.model.wait_for_idle(
+            apps=[APP_NAME, MANUAL_TLS_NAME],
+            idle_period=30,
+            timeout=1000,
+            raise_on_error=False,
+        )
+
+    ca_file = sign_manual_certs(tmp_path, juju.model)
+
+    juju.ext.model.wait_for_idle(
+        apps=[APP_NAME, MANUAL_TLS_NAME],
+        idle_period=30,
+        timeout=1000,
+        raise_on_error=False,
+        status="active",
+    )
+
+    for unit in juju.ext.model.applications[APP_NAME].units:
+        response = make_connect_api_request(juju, unit=unit, proto="https", verify=ca_file)
+        assert response.status_code == 200

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -260,6 +260,7 @@ def test_sans_change_leads_to_new_cert_request(
         local_app_data={"tls": "enabled"},
         local_unit_data={
             TLSContext.CERT: tls_artifacts.cert.decode("utf-8"),
+            TLSContext.CA: tls_artifacts.ca.decode("utf-8"),
             TLSContext.PRIVATE_KEY: tls_artifacts.private_key.decode("utf-8"),
             TLSContext.CSR: "old-csr",
             "private-address": "10.10.10.10",


### PR DESCRIPTION
## Description

Fixes https://github.com/canonical/kafka-operator/issues/567, also improves TLS UX for manual TLS operations by adding a `NO_CERT` status, similar to Kafka charm.

### Change Details

- Adds a `tls_enabled` property to `Context`, which checks both unit and app databags. Uses this new property for TLS enabled checks instead of `Context.peer_workers.tls_enabled` across the code.
- Adds `NO_CERT` status and related check to `Context.ready`
- Adds `log_on_error` argument to workload, to silent `import_cert` cert exists error logs
- Filters meaningless insecure request warnings in `ConnectManager` flooding juju debug logs when TLS is enabled 
- Adds integration tests for manual TLS operator.